### PR TITLE
feat(state): add state versions API, diff engine, and CLI commands

### DIFF
--- a/src/terrapyne/api/client.py
+++ b/src/terrapyne/api/client.py
@@ -11,6 +11,7 @@ from terrapyne.core.credentials import TerraformCredentials
 if TYPE_CHECKING:
     from terrapyne.api.projects import ProjectAPI
     from terrapyne.api.runs import RunsAPI
+    from terrapyne.api.state_versions import StateVersionsAPI
     from terrapyne.api.teams import TeamsAPI
     from terrapyne.api.workspaces import WorkspaceAPI
 
@@ -80,6 +81,13 @@ class TFCClient:
         from terrapyne.api.teams import TeamsAPI
 
         return TeamsAPI(self)
+
+    @property
+    def state_versions(self) -> "StateVersionsAPI":
+        """Get state versions API instance."""
+        from terrapyne.api.state_versions import StateVersionsAPI
+
+        return StateVersionsAPI(self)
 
     @retry(
         stop=stop_after_attempt(3),

--- a/src/terrapyne/api/state_versions.py
+++ b/src/terrapyne/api/state_versions.py
@@ -1,0 +1,130 @@
+"""Terraform Cloud State Versions API."""
+
+from __future__ import annotations
+
+import builtins
+from datetime import UTC, datetime
+from typing import Any
+
+from terrapyne.models.state_version import StateVersion, StateVersionOutput
+
+
+class StateVersionsAPI:
+    """State Versions API operations."""
+
+    def __init__(self, client: Any):
+        self.client = client
+
+    def list(  # noqa: A003
+        self,
+        workspace_id: str | None = None,
+        organization: str | None = None,
+        workspace_name: str | None = None,
+        limit: int = 20,
+    ) -> tuple[builtins.list[StateVersion], int | None]:
+        """List state versions for a workspace.
+
+        Can filter by workspace ID or by org+name. The TFC API supports both.
+
+        Args:
+            workspace_id: Workspace ID (used if org/name not provided)
+            organization: Organization name (for name-based filtering)
+            workspace_name: Workspace name (for name-based filtering)
+            limit: Maximum versions to return
+
+        Returns:
+            Tuple of (list of StateVersion most recent first, total count or None)
+        """
+        path = "/state-versions"
+        params: dict[str, Any] = {}
+
+        if organization and workspace_name:
+            params["filter[organization][name]"] = organization
+            params["filter[workspace][name]"] = workspace_name
+        else:
+            params["filter[workspace][id]"] = workspace_id
+
+        items_iter, total_count = self.client.paginate_with_meta(path, params=params)
+
+        versions = []
+        for item in items_iter:
+            versions.append(StateVersion.from_api_response(item))
+            if len(versions) >= limit:
+                break
+
+        return versions, total_count
+
+    def get(self, state_version_id: str) -> StateVersion:
+        """Get a state version by ID."""
+        path = f"/state-versions/{state_version_id}"
+        response = self.client.get(path)
+        return StateVersion.from_api_response(response["data"])
+
+    def get_current(self, workspace_id: str) -> StateVersion:
+        """Get the current (latest) state version for a workspace."""
+        path = f"/workspaces/{workspace_id}/current-state-version"
+        response = self.client.get(path)
+        return StateVersion.from_api_response(response["data"])
+
+    def download(self, state_version_id: str) -> dict[str, Any]:
+        """Download raw state JSON for a state version.
+
+        Follows the signed hosted-state-download-url.
+        """
+        sv = self.get(state_version_id)
+        if not sv.download_url:
+            raise ValueError(f"State version {state_version_id} has no download URL")
+        response = self.client.client.get(sv.download_url)
+        response.raise_for_status()
+        return response.json()
+
+    def download_from_url(self, download_url: str) -> dict[str, Any]:
+        """Download raw state JSON from a signed URL directly."""
+        response = self.client.client.get(download_url)
+        response.raise_for_status()
+        return response.json()
+
+    def list_outputs(self, state_version_id: str) -> builtins.list[StateVersionOutput]:
+        """List outputs for a state version without downloading full state."""
+        path = f"/state-versions/{state_version_id}/outputs"
+        outputs = []
+        for item in self.client.paginate(path):
+            attrs = item.get("attributes", {})
+            outputs.append(
+                StateVersionOutput(
+                    name=attrs.get("name", ""),
+                    value=attrs.get("value"),
+                    type=attrs.get("type"),
+                    sensitive=attrs.get("sensitive", False),
+                )
+            )
+        return outputs
+
+    def find_version_before(self, workspace_id: str, before: datetime) -> StateVersion | None:
+        """Find the last state version created before a given datetime.
+
+        Walks state versions (most recent first) and returns the first one
+        with created_at < before. Early exits — does not fetch all versions.
+
+        Both sides are normalized to UTC to avoid naive/aware comparison errors.
+        """
+
+        # Ensure 'before' is timezone-aware (UTC)
+        if before.tzinfo is None:
+            before = before.replace(tzinfo=UTC)
+
+        path = "/state-versions"
+        params = {"filter[workspace][id]": workspace_id}
+
+        for item in self.client.paginate(path, params=params):
+            sv = StateVersion.from_api_response(item)
+            if not sv.created_at:
+                continue
+            # Ensure created_at is timezone-aware (UTC)
+            created = sv.created_at
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=UTC)
+            if created < before:
+                return sv
+
+        return None

--- a/src/terrapyne/cli/main.py
+++ b/src/terrapyne/cli/main.py
@@ -3,7 +3,15 @@
 import typer
 from rich.console import Console
 
-from terrapyne.cli import debug_cmd, project_cmd, run_cmd, team_cmd, vcs_cmd, workspace_cmd
+from terrapyne.cli import (
+    debug_cmd,
+    project_cmd,
+    run_cmd,
+    state_cmd,
+    team_cmd,
+    vcs_cmd,
+    workspace_cmd,
+)
 
 app = typer.Typer(
     name="terrapyne",
@@ -29,6 +37,9 @@ app.add_typer(debug_cmd.app, name="debug")
 
 # Add project commands (placeholder)
 app.add_typer(project_cmd.app, name="project")
+
+# Add state commands
+app.add_typer(state_cmd.app, name="state")
 
 
 def version_callback(value: bool) -> None:

--- a/src/terrapyne/cli/state_cmd.py
+++ b/src/terrapyne/cli/state_cmd.py
@@ -1,0 +1,356 @@
+"""State version CLI commands."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from terrapyne.api.client import TFCClient
+from terrapyne.cli.utils import validate_context
+from terrapyne.core.state_diff import (
+    DEFAULT_FIELDS,
+    diff_state_resources,
+    extract_rows,
+    format_diff_unified,
+    parse_state_resources,
+)
+
+app = typer.Typer(help="State version commands", no_args_is_help=True)
+console = Console()
+
+
+def _parse_since(since: str) -> datetime:
+    """Parse a --since value into a timezone-aware datetime."""
+    try:
+        dt = datetime.fromisoformat(since)
+    except ValueError:
+        console.print(
+            f"[red]Error: Cannot parse date '{since}'. Use ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS).[/red]"
+        )
+        raise typer.Exit(1) from None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _parse_fields(fields: str | None) -> list[str]:
+    return [f.strip() for f in fields.split(",")] if fields else DEFAULT_FIELDS
+
+
+def _parse_types(types: str | None) -> set[str] | None:
+    return {t.strip() for t in types.split(",")} if types else None
+
+
+def _require_download_url(sv: Any) -> str:
+    """Extract download URL from a state version, or exit with error."""
+    if not sv.download_url:
+        console.print(
+            f"[red]Error: State version {sv.id} has no download URL "
+            f"(status: {sv.status}). The state may still be processing.[/red]"
+        )
+        raise typer.Exit(1)
+    return sv.download_url
+
+
+@app.command("list")
+def state_list(
+    workspace: str | None = typer.Argument(None, help="Workspace name"),
+    organization: str | None = typer.Option(None, "-o", "--organization"),
+    limit: int = typer.Option(20, "-n", "--limit", help="Max versions to show"),
+) -> None:
+    """List state versions for a workspace."""
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+
+    with TFCClient(organization=org) as client:
+        ws = client.workspaces.get(ws_name or "", org)
+        versions, total = client.state_versions.list(ws.id, limit=limit)
+
+    table = Table(title=f"State versions for {ws_name}")
+    table.add_column("#", style="dim")
+    table.add_column("ID")
+    table.add_column("Serial", justify="right")
+    table.add_column("Created")
+    table.add_column("Status")
+    table.add_column("Resources", justify="right")
+    table.add_column("Run ID", style="dim")
+
+    for i, sv in enumerate(versions, 1):
+        created = sv.created_at.strftime("%Y-%m-%d %H:%M") if sv.created_at else ""
+        table.add_row(
+            str(i),
+            sv.id,
+            str(sv.serial),
+            created,
+            sv.status or "",
+            str(sv.resource_count),
+            sv.run_id or "",
+        )
+
+    console.print(table)
+    if total is not None:
+        console.print(f"[dim]Showing {min(limit, total)} of {total} state versions[/dim]")
+
+
+@app.command("show")
+def state_show(
+    state_version_id: str | None = typer.Argument(None, help="State version ID"),
+    workspace: str | None = typer.Option(None, "-w", "--workspace"),
+    organization: str | None = typer.Option(None, "-o", "--organization"),
+    latest: bool = typer.Option(False, "--latest", help="Show the current/latest state version"),
+) -> None:
+    """Show state version metadata."""
+    org, ws_name = validate_context(organization, workspace)
+
+    with TFCClient(organization=org) as client:
+        if latest or not state_version_id:
+            if not ws_name:
+                console.print("[red]Error: Workspace required for --latest[/red]")
+                raise typer.Exit(1)
+            ws = client.workspaces.get(ws_name, org)
+            sv = client.state_versions.get_current(ws.id)
+        else:
+            sv = client.state_versions.get(state_version_id)
+
+    console.print(f"[bold]State Version:[/bold] {sv.id}")
+    console.print(f"  Serial:     {sv.serial}")
+    console.print(f"  Status:     {sv.status}")
+    console.print(f"  Created:    {sv.created_at}")
+    console.print(f"  Resources:  {sv.resource_count}")
+    console.print(f"  Providers:  {sv.providers_count}")
+    if sv.run_id:
+        console.print(f"  Run:        {sv.run_id}")
+
+
+@app.command("pull")
+def state_pull(
+    state_version_id: str | None = typer.Argument(None, help="State version ID (default: latest)"),
+    workspace: str | None = typer.Option(None, "-w", "--workspace"),
+    organization: str | None = typer.Option(None, "-o", "--organization"),
+) -> None:
+    """Download state JSON to stdout (like terraform state pull)."""
+    org, ws_name = validate_context(organization, workspace)
+
+    with TFCClient(organization=org) as client:
+        if state_version_id:
+            state = client.state_versions.download(state_version_id)
+        else:
+            if not ws_name:
+                console.print("[red]Error: Workspace required when no state version ID given[/red]")
+                raise typer.Exit(1)
+            ws = client.workspaces.get(ws_name, org)
+            sv = client.state_versions.get_current(ws.id)
+            state = client.state_versions.download_from_url(_require_download_url(sv))
+
+    # Raw JSON to stdout — not through rich, so it's pipeable
+    print(json.dumps(state, indent=2))
+
+
+@app.command("outputs")
+def state_outputs(
+    state_version_id: str | None = typer.Argument(None, help="State version ID (default: latest)"),
+    workspace: str | None = typer.Option(None, "-w", "--workspace"),
+    organization: str | None = typer.Option(None, "-o", "--organization"),
+    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table, json"),
+) -> None:
+    """List outputs from a state version."""
+    org, ws_name = validate_context(organization, workspace)
+
+    with TFCClient(organization=org) as client:
+        if not state_version_id:
+            if not ws_name:
+                console.print("[red]Error: Workspace required when no state version ID given[/red]")
+                raise typer.Exit(1)
+            ws = client.workspaces.get(ws_name, org)
+            sv = client.state_versions.get_current(ws.id)
+            state_version_id = sv.id
+
+        outputs = client.state_versions.list_outputs(state_version_id)
+
+    if output_format == "json":
+        print(
+            json.dumps(
+                [
+                    {"name": o.name, "value": o.value, "type": o.type, "sensitive": o.sensitive}
+                    for o in outputs
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    table = Table(title="State Outputs")
+    table.add_column("Name")
+    table.add_column("Value")
+    table.add_column("Type", style="dim")
+    table.add_column("Sensitive")
+
+    for o in outputs:
+        val = "(sensitive)" if o.sensitive else str(o.value)
+        table.add_row(o.name, val, o.type or "", "yes" if o.sensitive else "")
+
+    console.print(table)
+
+
+@app.command("inventory")
+def state_inventory(
+    workspace: str | None = typer.Argument(None, help="Workspace name"),
+    organization: str | None = typer.Option(None, "-o", "--organization"),
+    fields: str | None = typer.Option(
+        None, "--fields", help="Comma-separated fields (e.g. type,tags.Name,id,arn)"
+    ),
+    type_filter: str | None = typer.Option(
+        None, "--type", help="Filter resource types (comma-separated)"
+    ),
+    mode: str = typer.Option("managed", "--mode", help="Resource mode: managed, data"),
+    module: str | None = typer.Option(None, "--module", help="Filter by module path substring"),
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="Output format: table, markdown, json"
+    ),
+) -> None:
+    """Show current resource inventory from latest state."""
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+    field_list = _parse_fields(fields)
+    type_set = _parse_types(type_filter)
+
+    with TFCClient(organization=org) as client:
+        ws = client.workspaces.get(ws_name or "", org)
+        sv = client.state_versions.get_current(ws.id)
+        state = client.state_versions.download_from_url(_require_download_url(sv))
+
+    instances = parse_state_resources(state, types=type_set, mode=mode, module_pattern=module)
+    rows = extract_rows(instances, field_list)
+
+    _render_rows(rows, field_list, output_format, title=f"Resources in {ws_name}")
+
+
+@app.command("diff")
+def state_diff(
+    workspace: str | None = typer.Argument(None, help="Workspace name"),
+    organization: str | None = typer.Option(None, "-o", "--organization"),
+    since: str = typer.Option(..., "--since", help="Date to diff from (ISO format: YYYY-MM-DD)"),
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated fields"),
+    type_filter: str | None = typer.Option(None, "--type", help="Filter resource types"),
+    mode: str = typer.Option("managed", "--mode"),
+    module: str | None = typer.Option(None, "--module"),
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="Output format: table, markdown, json, diff"
+    ),
+    diff_cmd: str | None = typer.Option(
+        None,
+        "--diff-cmd",
+        help="External diff program (e.g. 'delta', 'git diff --no-index --color')",
+    ),
+) -> None:
+    """Show resources added/removed since a date."""
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+    since_dt = _parse_since(since)
+    field_list = _parse_fields(fields)
+    type_set = _parse_types(type_filter)
+
+    with TFCClient(organization=org) as client:
+        ws = client.workspaces.get(ws_name or "", org)
+
+        # Current state
+        sv_new = client.state_versions.get_current(ws.id)
+        state_new = client.state_versions.download_from_url(_require_download_url(sv_new))
+
+        # State before the given date
+        sv_old = client.state_versions.find_version_before(ws.id, since_dt)
+        state_old = (
+            client.state_versions.download_from_url(_require_download_url(sv_old)) if sv_old else {}
+        )
+
+    new_instances = parse_state_resources(
+        state_new, types=type_set, mode=mode, module_pattern=module
+    )
+    old_instances = (
+        parse_state_resources(state_old, types=type_set, mode=mode, module_pattern=module)
+        if state_old
+        else []
+    )
+
+    if output_format == "diff":
+        output = format_diff_unified(old_instances, new_instances, field_list, diff_cmd=diff_cmd)
+        print(output, end="")
+        return
+
+    result = diff_state_resources(old_instances, new_instances)
+
+    since_label = since_dt.strftime("%Y-%m-%d")
+    old_serial = f" (serial {sv_old.serial})" if sv_old else " (no prior state)"
+    console.print(
+        f"[dim]Comparing current (serial {sv_new.serial}) vs state before {since_label}{old_serial}[/dim]\n"
+    )
+
+    if not result.added and not result.removed:
+        console.print(f"[green]No resource changes since {since_label}[/green]")
+        return
+
+    if result.added:
+        rows = extract_rows(result.added, field_list)
+        _render_rows(
+            rows, field_list, output_format, title=f"Added ({len(result.added)})", action="+"
+        )
+
+    if result.removed:
+        rows = extract_rows(result.removed, field_list)
+        _render_rows(
+            rows, field_list, output_format, title=f"Removed ({len(result.removed)})", action="-"
+        )
+
+
+def _render_rows(
+    rows: list[dict[str, str]],
+    fields: list[str],
+    output_format: str,
+    title: str = "",
+    action: str | None = None,
+) -> None:
+    """Render rows in the requested format."""
+    if output_format == "json":
+        if action:
+            for row in rows:
+                row["_action"] = action
+        print(json.dumps(rows, indent=2))
+
+    elif output_format == "markdown":
+        cols = ["#"]
+        if action:
+            cols.append("")
+        cols.extend(fields)
+        header = "| " + " | ".join(cols) + " |"
+        separator = "| " + " | ".join("---" for _ in cols) + " |"
+
+        if title:
+            console.print(f"\n**{title}**\n")
+        print(header)
+        print(separator)
+        for i, row in enumerate(rows, 1):
+            prefix = f" {action} |" if action else ""
+            vals = " | ".join(row.get(f, "") for f in fields)
+            print(f"| {i} |{prefix} {vals} |")
+
+    else:  # table (default)
+        table = Table(title=title)
+        table.add_column("#", style="dim", justify="right")
+        if action:
+            table.add_column("", width=1)
+        for f in fields:
+            table.add_column(f)
+
+        for i, row in enumerate(rows, 1):
+            action_cell = (
+                "[green]+[/green]" if action == "+" else "[red]-[/red]" if action == "-" else ""
+            )
+            cells = [str(i)]
+            if action:
+                cells.append(action_cell)
+            cells.extend(row.get(f, "") for f in fields)
+            table.add_row(*cells)
+
+        console.print(table)

--- a/src/terrapyne/core/state_diff.py
+++ b/src/terrapyne/core/state_diff.py
@@ -1,0 +1,240 @@
+"""State resource extraction and diffing."""
+
+from __future__ import annotations
+
+import difflib
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class StateResourceInstance:
+    """A single instance of a resource in terraform state."""
+
+    resource_type: str
+    resource_name: str
+    module: str | None
+    index_key: int | str | None
+    attributes: dict[str, Any]
+
+    @property
+    def address(self) -> str:
+        base = f"{self.resource_type}.{self.resource_name}"
+        if self.module:
+            base = f"{self.module}.{base}"
+        if self.index_key is not None:
+            base = f"{base}[{self.index_key}]"
+        return base
+
+    def get_field(self, dotted_path: str) -> Any:
+        """Get a value from attributes using a dotted path like 'tags.Name'."""
+        obj: Any = self.attributes
+        for key in dotted_path.split("."):
+            if isinstance(obj, dict):
+                obj = obj.get(key)
+            else:
+                return None
+            if obj is None:
+                return None
+        return obj
+
+
+def parse_state_resources(
+    state_json: dict[str, Any],
+    types: set[str] | None = None,
+    mode: str = "managed",
+    module_pattern: str | None = None,
+) -> list[StateResourceInstance]:
+    """Extract resource instances from a terraform state JSON.
+
+    Args:
+        state_json: Parsed terraform state (from state version download)
+        types: Filter to these resource types (None = all)
+        mode: Filter by mode ('managed', 'data', or None for all)
+        module_pattern: Filter to resources in modules matching this substring
+
+    Returns:
+        List of StateResourceInstance
+    """
+    instances = []
+    for resource in state_json.get("resources", []):
+        if mode and resource.get("mode") != mode:
+            continue
+        rtype = resource.get("type", "")
+        if types and rtype not in types:
+            continue
+        rmodule = resource.get("module")
+        if module_pattern and (not rmodule or module_pattern not in rmodule):
+            continue
+
+        rname = resource.get("name", "")
+        for inst in resource.get("instances", []):
+            instances.append(
+                StateResourceInstance(
+                    resource_type=rtype,
+                    resource_name=rname,
+                    module=rmodule,
+                    index_key=inst.get("index_key"),
+                    attributes=inst.get("attributes", {}),
+                )
+            )
+    return instances
+
+
+DEFAULT_FIELDS = ["type", "name", "id", "arn", "region"]
+
+# Fallback key search per logical field (like orc.py but configurable)
+FIELD_ALIASES: dict[str, list[str]] = {
+    "type": [],  # special — uses resource_type
+    "name": ["tags.Name", "name", "identifier", "id"],
+    "id": ["id", "arn"],
+    "arn": ["arn", "certificate_arn"],
+    "region": ["region", "availability_zone"],
+    "endpoint": ["private_ip", "endpoint", "arn", "uri"],
+}
+
+
+def resolve_field(instance: StateResourceInstance, field_name: str) -> str:
+    """Resolve a field name to a value, using aliases for well-known fields."""
+    if field_name == "type":
+        return instance.resource_type
+    if field_name == "address":
+        return instance.address
+    if field_name == "module":
+        return instance.module or "(root)"
+
+    # Try direct dotted path first
+    val = instance.get_field(field_name)
+    if val is not None:
+        return str(val)
+
+    # Try aliases for well-known field names
+    for alias in FIELD_ALIASES.get(field_name, []):
+        val = instance.get_field(alias)
+        if val is not None:
+            return str(val)
+
+    return ""
+
+
+def extract_rows(
+    instances: list[StateResourceInstance],
+    fields: list[str],
+) -> list[dict[str, str]]:
+    """Extract field values from instances into row dicts."""
+    return [{f: resolve_field(inst, f) for f in fields} for inst in instances]
+
+
+@dataclass
+class StateDiff:
+    """Result of diffing two state snapshots."""
+
+    added: list[StateResourceInstance] = field(default_factory=list)
+    removed: list[StateResourceInstance] = field(default_factory=list)
+
+
+def diff_state_resources(
+    old_instances: list[StateResourceInstance],
+    new_instances: list[StateResourceInstance],
+) -> StateDiff:
+    """Compute resource delta between two state snapshots.
+
+    Uses resource address as the identity key.
+    """
+    old_by_addr = {i.address: i for i in old_instances}
+    new_by_addr = {i.address: i for i in new_instances}
+
+    old_addrs = set(old_by_addr.keys())
+    new_addrs = set(new_by_addr.keys())
+
+    return StateDiff(
+        added=sorted(
+            [new_by_addr[a] for a in new_addrs - old_addrs],
+            key=lambda i: i.address,
+        ),
+        removed=sorted(
+            [old_by_addr[a] for a in old_addrs - new_addrs],
+            key=lambda i: i.address,
+        ),
+    )
+
+
+def format_diff_unified(
+    old_instances: list[StateResourceInstance],
+    new_instances: list[StateResourceInstance],
+    fields: list[str],
+    diff_cmd: str | None = None,
+) -> str:
+    """Produce a unified diff of two state snapshots.
+
+    If diff_cmd is provided, writes temp files and shells out to that program.
+    Otherwise uses difflib with ANSI colouring when stdout is a TTY.
+    """
+    old_rows = extract_rows(old_instances, fields)
+    new_rows = extract_rows(new_instances, fields)
+
+    old_text = json.dumps(old_rows, indent=2, sort_keys=True).splitlines(keepends=True)
+    new_text = json.dumps(new_rows, indent=2, sort_keys=True).splitlines(keepends=True)
+
+    if diff_cmd:
+        return _external_diff(old_text, new_text, diff_cmd)
+
+    diff_lines = list(
+        difflib.unified_diff(old_text, new_text, fromfile="old-state", tofile="new-state")
+    )
+
+    if not diff_lines:
+        return "No differences.\n"
+
+    if sys.stdout.isatty():
+        return _colorize_diff(diff_lines)
+
+    return "".join(diff_lines)
+
+
+_ANSI_RED = "\033[31m"
+_ANSI_GREEN = "\033[32m"
+_ANSI_CYAN = "\033[36m"
+_ANSI_RESET = "\033[0m"
+
+
+def _colorize_diff(lines: list[str]) -> str:
+    out = []
+    for line in lines:
+        if line.startswith("+++") or line.startswith("---"):
+            out.append(f"{_ANSI_CYAN}{line}{_ANSI_RESET}")
+        elif line.startswith("+"):
+            out.append(f"{_ANSI_GREEN}{line}{_ANSI_RESET}")
+        elif line.startswith("-"):
+            out.append(f"{_ANSI_RED}{line}{_ANSI_RESET}")
+        else:
+            out.append(line)
+    return "".join(out)
+
+
+def _external_diff(old_lines: list[str], new_lines: list[str], diff_cmd: str) -> str:
+    """Write to temp files and run an external diff program."""
+    import tempfile
+
+    with (
+        tempfile.NamedTemporaryFile(mode="w", suffix="-old-state.json", delete=False) as old_f,
+        tempfile.NamedTemporaryFile(mode="w", suffix="-new-state.json", delete=False) as new_f,
+    ):
+        old_f.writelines(old_lines)
+        new_f.writelines(new_lines)
+        old_path, new_path = old_f.name, new_f.name
+
+    try:
+        # Support "git diff --no-index --color" style multi-word commands
+        cmd_parts = shlex.split(diff_cmd) + [old_path, new_path]
+        result = subprocess.run(cmd_parts, capture_output=True, text=True)
+        # diff tools return exit code 1 when files differ — that's normal
+        return result.stdout or result.stderr or "No differences.\n"
+    finally:
+        os.unlink(old_path)
+        os.unlink(new_path)

--- a/src/terrapyne/models/__init__.py
+++ b/src/terrapyne/models/__init__.py
@@ -4,6 +4,7 @@ from .apply import Apply
 from .plan import Plan
 from .project import Project
 from .run import Run, RunStatus
+from .state_version import StateVersion, StateVersionOutput
 from .team import Team
 from .team_access import TeamProjectAccess
 from .variable import WorkspaceVariable
@@ -16,6 +17,8 @@ __all__ = [
     "Project",
     "Run",
     "RunStatus",
+    "StateVersion",
+    "StateVersionOutput",
     "Team",
     "TeamProjectAccess",
     "WorkspaceVariable",

--- a/src/terrapyne/models/state_version.py
+++ b/src/terrapyne/models/state_version.py
@@ -1,0 +1,56 @@
+"""Terraform Cloud state version models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from terrapyne.models.utils import parse_iso_datetime
+
+
+class StateVersionOutput(BaseModel):
+    """A single output from a state version."""
+
+    name: str
+    value: Any = None
+    type: str | None = None
+    sensitive: bool = False
+
+
+class StateVersion(BaseModel):
+    """Terraform Cloud state version."""
+
+    id: str
+    serial: int = 0
+    created_at: datetime | None = Field(None, alias="created-at")
+    status: str | None = None
+    download_url: str | None = Field(None, alias="hosted-state-download-url")
+    resource_count: int = Field(0, alias="resource-count")
+    providers_count: int = Field(0, alias="providers-count")
+    resources_processed: bool = Field(False, alias="resources-processed")
+    run_id: str | None = None
+
+    class Config:
+        populate_by_name = True
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any]) -> StateVersion:
+        attrs = data.get("attributes", {})
+        run_id = None
+        relationships = data.get("relationships", {})
+        if relationships.get("run", {}).get("data"):
+            run_id = relationships["run"]["data"].get("id")
+
+        return cls.model_construct(
+            id=data["id"],
+            serial=attrs.get("serial", 0),
+            created_at=parse_iso_datetime(attrs.get("created-at")),
+            status=attrs.get("status"),
+            download_url=attrs.get("hosted-state-download-url"),
+            resource_count=attrs.get("resource-count", 0),
+            providers_count=attrs.get("providers-count", 0),
+            resources_processed=attrs.get("resources-processed", False),
+            run_id=run_id,
+        )

--- a/tests/unit/test_state_diff.py
+++ b/tests/unit/test_state_diff.py
@@ -1,0 +1,247 @@
+"""Tests for state diff and resource extraction."""
+
+from terrapyne.core.state_diff import (
+    StateDiff,
+    StateResourceInstance,
+    diff_state_resources,
+    extract_rows,
+    format_diff_unified,
+    parse_state_resources,
+    resolve_field,
+)
+from terrapyne.models.state_version import StateVersion, StateVersionOutput
+
+
+SAMPLE_STATE = {
+    "resources": [
+        {
+            "module": "module.vpc",
+            "mode": "managed",
+            "type": "aws_subnet",
+            "name": "private",
+            "instances": [
+                {"index_key": 0, "attributes": {"id": "subnet-aaa", "arn": "arn:aws:ec2:us-east-1:123:subnet/subnet-aaa", "tags": {"Name": "private-0"}, "availability_zone": "us-east-1a"}},
+                {"index_key": 1, "attributes": {"id": "subnet-bbb", "arn": "arn:aws:ec2:us-east-1:123:subnet/subnet-bbb", "tags": {"Name": "private-1"}, "availability_zone": "us-east-1b"}},
+            ],
+        },
+        {
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "web",
+            "instances": [
+                {"attributes": {"id": "i-12345", "arn": "arn:aws:ec2:us-east-1:123:instance/i-12345", "tags": {"Name": "web-server"}, "private_ip": "10.0.1.5"}},
+            ],
+        },
+        {
+            "mode": "data",
+            "type": "aws_ami",
+            "name": "ubuntu",
+            "instances": [
+                {"attributes": {"id": "ami-abc123", "name": "ubuntu-22.04"}},
+            ],
+        },
+    ]
+}
+
+
+class TestParseStateResources:
+    def test_parse_all_managed(self):
+        result = parse_state_resources(SAMPLE_STATE)
+        assert len(result) == 3  # 2 subnets + 1 instance (data source excluded)
+
+    def test_filter_by_type(self):
+        result = parse_state_resources(SAMPLE_STATE, types={"aws_instance"})
+        assert len(result) == 1
+        assert result[0].resource_type == "aws_instance"
+
+    def test_filter_by_mode_data(self):
+        result = parse_state_resources(SAMPLE_STATE, mode="data")
+        assert len(result) == 1
+        assert result[0].resource_type == "aws_ami"
+
+    def test_filter_by_module(self):
+        result = parse_state_resources(SAMPLE_STATE, module_pattern="module.vpc")
+        assert len(result) == 2
+        assert all(i.module == "module.vpc" for i in result)
+
+    def test_root_resource_has_no_module(self):
+        result = parse_state_resources(SAMPLE_STATE, types={"aws_instance"})
+        assert result[0].module is None
+
+
+class TestStateResourceInstance:
+    def test_address_with_module_and_index(self):
+        inst = StateResourceInstance(
+            resource_type="aws_subnet", resource_name="private",
+            module="module.vpc", index_key=0, attributes={},
+        )
+        assert inst.address == "module.vpc.aws_subnet.private[0]"
+
+    def test_address_root_no_index(self):
+        inst = StateResourceInstance(
+            resource_type="aws_instance", resource_name="web",
+            module=None, index_key=None, attributes={},
+        )
+        assert inst.address == "aws_instance.web"
+
+    def test_get_field_dotted_path(self):
+        inst = StateResourceInstance(
+            resource_type="aws_instance", resource_name="web",
+            module=None, index_key=None,
+            attributes={"tags": {"Name": "my-server"}, "id": "i-123"},
+        )
+        assert inst.get_field("tags.Name") == "my-server"
+        assert inst.get_field("id") == "i-123"
+        assert inst.get_field("nonexistent.path") is None
+
+
+class TestResolveField:
+    def test_type_field(self):
+        inst = StateResourceInstance("aws_instance", "web", None, None, {})
+        assert resolve_field(inst, "type") == "aws_instance"
+
+    def test_address_field(self):
+        inst = StateResourceInstance("aws_instance", "web", "module.app", None, {})
+        assert resolve_field(inst, "address") == "module.app.aws_instance.web"
+
+    def test_name_uses_alias_fallback(self):
+        inst = StateResourceInstance("aws_instance", "web", None, None, {"tags": {"Name": "my-web"}})
+        assert resolve_field(inst, "name") == "my-web"
+
+    def test_direct_dotted_path(self):
+        inst = StateResourceInstance("aws_instance", "web", None, None, {"tags": {"Environment": "prod"}})
+        assert resolve_field(inst, "tags.Environment") == "prod"
+
+
+class TestDiffStateResources:
+    def test_all_added_when_old_empty(self):
+        new = parse_state_resources(SAMPLE_STATE)
+        result = diff_state_resources([], new)
+        assert len(result.added) == 3
+        assert len(result.removed) == 0
+
+    def test_all_removed_when_new_empty(self):
+        old = parse_state_resources(SAMPLE_STATE)
+        result = diff_state_resources(old, [])
+        assert len(result.removed) == 3
+        assert len(result.added) == 0
+
+    def test_identical_states_no_diff(self):
+        instances = parse_state_resources(SAMPLE_STATE)
+        result = diff_state_resources(instances, instances)
+        assert len(result.added) == 0
+        assert len(result.removed) == 0
+
+    def test_detects_added_resource(self):
+        old = parse_state_resources(SAMPLE_STATE, types={"aws_subnet"})
+        new = parse_state_resources(SAMPLE_STATE)  # includes aws_instance too
+        result = diff_state_resources(old, new)
+        assert len(result.added) == 1
+        assert result.added[0].resource_type == "aws_instance"
+
+
+class TestExtractRows:
+    def test_extracts_requested_fields(self):
+        instances = parse_state_resources(SAMPLE_STATE, types={"aws_instance"})
+        rows = extract_rows(instances, ["type", "id", "tags.Name"])
+        assert len(rows) == 1
+        assert rows[0]["type"] == "aws_instance"
+        assert rows[0]["id"] == "i-12345"
+        assert rows[0]["tags.Name"] == "web-server"
+
+
+class TestFormatDiffUnified:
+    def test_no_differences(self):
+        instances = parse_state_resources(SAMPLE_STATE)
+        output = format_diff_unified(instances, instances, ["type", "id"])
+        assert "No differences" in output
+
+    def test_produces_diff_output(self):
+        old = parse_state_resources(SAMPLE_STATE, types={"aws_subnet"})
+        new = parse_state_resources(SAMPLE_STATE)
+        output = format_diff_unified(old, new, ["type", "id"])
+        assert "aws_instance" in output
+
+
+class TestStateVersionModel:
+    def test_from_api_response(self):
+        data = {
+            "id": "sv-abc123",
+            "attributes": {
+                "serial": 42,
+                "created-at": "2025-06-15T10:30:00Z",
+                "status": "finalized",
+                "hosted-state-download-url": "https://archivist.terraform.io/v1/object/abc",
+                "resource-count": 15,
+                "providers-count": 3,
+                "resources-processed": True,
+            },
+            "relationships": {
+                "run": {"data": {"id": "run-xyz789", "type": "runs"}},
+            },
+        }
+        sv = StateVersion.from_api_response(data)
+        assert sv.id == "sv-abc123"
+        assert sv.serial == 42
+        assert sv.status == "finalized"
+        assert sv.resource_count == 15
+        assert sv.run_id == "run-xyz789"
+        assert sv.download_url == "https://archivist.terraform.io/v1/object/abc"
+
+    def test_from_api_response_minimal(self):
+        data = {"id": "sv-min", "attributes": {}, "relationships": {}}
+        sv = StateVersion.from_api_response(data)
+        assert sv.id == "sv-min"
+        assert sv.serial == 0
+        assert sv.run_id is None
+
+
+class TestStateVersionOutput:
+    def test_basic(self):
+        o = StateVersionOutput(name="vpc_id", value="vpc-123", type="string", sensitive=False)
+        assert o.name == "vpc_id"
+        assert o.value == "vpc-123"
+
+
+class TestAddressWithStringIndex:
+    def test_string_index_key(self):
+        inst = StateResourceInstance(
+            resource_type="aws_route53_record",
+            resource_name="this",
+            module="module.dns",
+            index_key="app.example.com",
+            attributes={},
+        )
+        assert inst.address == 'module.dns.aws_route53_record.this[app.example.com]'
+
+
+class TestResolveFieldEdgeCases:
+    def test_unknown_field_returns_empty(self):
+        inst = StateResourceInstance("aws_instance", "web", None, None, {})
+        assert resolve_field(inst, "nonexistent") == ""
+
+    def test_module_field_root(self):
+        inst = StateResourceInstance("aws_instance", "web", None, None, {})
+        assert resolve_field(inst, "module") == "(root)"
+
+    def test_module_field_with_module(self):
+        inst = StateResourceInstance("aws_instance", "web", "module.app", None, {})
+        assert resolve_field(inst, "module") == "module.app"
+
+    def test_name_falls_back_to_id_when_no_tags(self):
+        inst = StateResourceInstance("aws_instance", "web", None, None, {"id": "i-fallback"})
+        # "name" alias chain: tags.Name -> name -> identifier -> id
+        assert resolve_field(inst, "name") == "i-fallback"
+
+
+class TestParseStateResourcesEdgeCases:
+    def test_empty_state(self):
+        assert parse_state_resources({}) == []
+
+    def test_no_instances(self):
+        state = {"resources": [{"mode": "managed", "type": "aws_instance", "name": "x", "instances": []}]}
+        assert parse_state_resources(state) == []
+
+    def test_mode_none_returns_all(self):
+        result = parse_state_resources(SAMPLE_STATE, mode=None)
+        assert len(result) == 4  # 2 subnets + 1 instance + 1 data source


### PR DESCRIPTION
## Summary

Add state version listing, download, diffing, and resource inventory — completing the run lifecycle (plan → apply → state).

---

## Why

**Driver:** Terrapyne could list runs and fetch plan/apply logs but had no way to inspect state. The `cse-team-tools/orc.py` script does state diffing with raw requests, no retry, no tests. This replaces it properly.

**Alternatives rejected:** Wrapping orc.py — it fetches all state versions without pagination, has no filtering, hardcodes resource types, uses `verify=False`.

---

## What changed

**Affected:** src/terrapyne/api/state_versions.py · src/terrapyne/core/state_diff.py · src/terrapyne/cli/state_cmd.py · src/terrapyne/models/state_version.py

- **StateVersionsAPI**: list, get, get_current, download (follows signed URL), find_version_before (early exit pagination)
- **State diff engine**: parse state resources, diff by address, unified diff with ANSI colouring
- **CLI commands**: state list/show/pull/outputs/inventory/diff
- **Format control**: `--fields type,tags.Name,id,arn` for column selection, `--format table|markdown|json|diff`
- **External diff**: `--diff-cmd delta` pipes to user's preferred diff tool
- **Filters**: `--type`, `--mode`, `--module` on inventory and diff
- Adversarial review (Bart) findings addressed: download URL guard, timezone safety, shlex.split

---

## Risk and review focus

**Look here first:** `state_diff.py` — the resource extraction and field resolution logic.

**Edge cases left for later:** No "changed" detection in diff (only added/removed). Large state files could OOM. No retry on signed URL downloads.

---

## Testing

**Scenarios tested:**
- Parse state with managed/data resources, module filtering, type filtering
- Resource address generation with modules and index keys
- Field resolution with dotted paths and alias fallbacks
- Diff: empty old state (all added), empty new state (all removed), identical states
- StateVersion model parsing from API response (full and minimal)
- Unified diff output with and without differences
- 286 total tests passing (30 new for state diff)

**Coverage delta:** 65% (new code well-tested, CLI commands add surface area)
