### PR TITLE
fix(cli): return exit code 0 when invoked without subcommand

### DIFF
--- a/src/terrapyne/cli/main.py
+++ b/src/terrapyne/cli/main.py
@@ -16,7 +16,6 @@ from terrapyne.cli import (
 app = typer.Typer(
     name="terrapyne",
     help="Terraform Cloud CLI orchestrator for DevOps engineers",
-    no_args_is_help=True,
 )
 console = Console()
 
@@ -49,8 +48,9 @@ def version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def main(
+    ctx: typer.Context,
     version: bool | None = typer.Option(
         None,
         "--version",
@@ -63,4 +63,5 @@ def main(
 
     Context-aware commands that auto-detect workspace and organization from terraform.tf.
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())


### PR DESCRIPTION
## Summary

`terrapyne` with no args now exits 0 instead of 2.

---

## Why

**Driver:** Non-zero exit code breaks shell scripts and CI that check `$?`.

**Alternatives rejected:** Suppressing the exit code in a wrapper — the CLI should just do the right thing.

---

## What changed

**Affected:** src/terrapyne/cli/main.py

Replace Typer's `no_args_is_help=True` (exits 2) with `invoke_without_command=True` callback that prints help and exits 0.

---

## Risk and review focus

**Look here first:** The callback — it's 3 lines.

---

## Testing

`uv run terrapyne` returns exit 0 with help output. 286 tests pass.
