### PR TITLE
fix(workspace): use resolved workspace name from context detection

### DIFF
--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -98,10 +98,10 @@ def workspace_show(
         # Show workspace in specific organization
         terrapyne workspace show my-app-dev --organization Takeda
     """
-    org, _ = validate_context(organization, workspace, require_workspace=True)
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
 
     with TFCClient(organization=org) as client:
-        ws = client.workspaces.get(workspace or "")
+        ws = client.workspaces.get(ws_name or "")
 
         # Render workspace details
         render_workspace_detail(ws)
@@ -141,10 +141,10 @@ def workspace_vcs(
         # Show VCS config for specific workspace
         terrapyne workspace vcs my-app-dev
     """
-    org, _ = validate_context(organization, workspace, require_workspace=True)
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
 
     with TFCClient(organization=org) as client:
-        ws = client.workspaces.get(workspace or "")
+        ws = client.workspaces.get(ws_name or "")
 
         if not ws.vcs_repo:
             console.print(f"[yellow]Workspace '{workspace}' has no VCS connection.[/yellow]")
@@ -196,10 +196,10 @@ def workspace_variables(
         # List variables in specific organization
         terrapyne workspace variables my-app-dev --organization Takeda
     """
-    org, _ = validate_context(organization, workspace, require_workspace=True)
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
 
     with TFCClient(organization=org) as client:
-        ws = client.workspaces.get(workspace or "")
+        ws = client.workspaces.get(ws_name or "")
         variables = client.workspaces.get_variables(ws.id)
 
         if not variables:
@@ -262,7 +262,7 @@ def workspace_var_set(
         # Import from .env file
         terrapyne workspace var-set --from-env-file .env.prod --sensitive
     """
-    org, _ = validate_context(organization, workspace, require_workspace=True)
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
 
     # 1. Collect variables to set
     to_set: dict[str, str] = {}
@@ -303,7 +303,7 @@ def workspace_var_set(
         raise typer.Exit(1)
 
     with TFCClient(organization=org) as client:
-        ws = client.workspaces.get(workspace or "")
+        ws = client.workspaces.get(ws_name or "")
         existing_variables: list[WorkspaceVariable] = client.workspaces.get_variables(ws.id)
 
         results = []


### PR DESCRIPTION
## Summary

Fix 4 commands that discard the auto-detected workspace name, crashing when called without an explicit workspace argument.

---

## Why

**Driver:** `tfc workspace show`, `variables`, `vcs`, and `var-set` crash when run inside a terraform directory without passing a workspace name. The resolved name from `validate_context()` was assigned to `_` and discarded.

---

## What changed

**Affected:** src/terrapyne/cli/workspace_cmd.py (4 sites)

```python
# Before — discards resolved workspace
org, _ = validate_context(organization, workspace, require_workspace=True)
ws = client.workspaces.get(workspace or "")  # workspace is None → "" → crash

# After — uses resolved workspace
org, ws_name = validate_context(organization, workspace, require_workspace=True)
ws = client.workspaces.get(ws_name or "")  # ws_name is the auto-detected name
```

---

## Risk and review focus

**Look here first:** The 4 changed lines — verify each `ws_name` flows to the right `.get()` call.

---

## Testing

289 tests pass. Verified manually: `tfc workspace show` from inside a terraform directory now auto-detects correctly.
