### PR TITLE
fix(cli): return exit code 0 for all subcommand help screens

### DIFF
--- a/src/terrapyne/cli/debug_cmd.py
+++ b/src/terrapyne/cli/debug_cmd.py
@@ -3,8 +3,14 @@
 import typer
 from rich.console import Console
 
-app = typer.Typer(help="Troubleshooting and debugging commands", no_args_is_help=True)
+app = typer.Typer(help="Troubleshooting and debugging commands")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
 
 
 @app.command("run")

--- a/src/terrapyne/cli/project_cmd.py
+++ b/src/terrapyne/cli/project_cmd.py
@@ -17,8 +17,14 @@ from terrapyne.utils.rich_tables import (
     render_projects,
 )
 
-app = typer.Typer(help="Project discovery and management commands", no_args_is_help=True)
+app = typer.Typer(help="Project discovery and management commands")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
 
 
 @app.command(name="list")

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -13,8 +13,14 @@ from terrapyne.models.run import Run
 from terrapyne.terrapyne import Terraform
 from terrapyne.utils.rich_tables import render_run_detail, render_runs
 
-app = typer.Typer(help="Run management commands", no_args_is_help=True)
+app = typer.Typer(help="Run management commands")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
 
 
 @app.command("list")

--- a/src/terrapyne/cli/state_cmd.py
+++ b/src/terrapyne/cli/state_cmd.py
@@ -20,8 +20,14 @@ from terrapyne.core.state_diff import (
     parse_state_resources,
 )
 
-app = typer.Typer(help="State version commands", no_args_is_help=True)
+app = typer.Typer(help="State version commands")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
 
 
 def _parse_since(since: str) -> datetime:

--- a/src/terrapyne/cli/team_cmd.py
+++ b/src/terrapyne/cli/team_cmd.py
@@ -7,8 +7,14 @@ from rich.table import Table
 from terrapyne.api.client import TFCClient
 from terrapyne.cli.utils import handle_cli_errors, validate_context
 
-app = typer.Typer(help="Team management commands", no_args_is_help=True)
+app = typer.Typer(help="Team management commands")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
 
 
 @app.command("list")

--- a/src/terrapyne/cli/vcs_cmd.py
+++ b/src/terrapyne/cli/vcs_cmd.py
@@ -14,8 +14,14 @@ from terrapyne.api.workspaces import WorkspaceAPI
 from terrapyne.cli.utils import handle_cli_errors, validate_context
 from terrapyne.utils.rich_tables import render_vcs_detail, render_vcs_repos
 
-app = typer.Typer(help="VCS operations (repository, branch management)", no_args_is_help=True)
+app = typer.Typer(help="VCS operations (repository, branch management)")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
 
 
 @app.command(name="show")

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -19,8 +19,14 @@ from terrapyne.utils.rich_tables import (
     render_workspaces,
 )
 
-app = typer.Typer(help="Workspace management commands", no_args_is_help=True)
+app = typer.Typer(help="Workspace management commands")
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
 
 
 @app.command("list")


### PR DESCRIPTION
## Summary

All 7 command groups now exit 0 when showing help, not 2.

---

## Why

**Driver:** `terrapyne workspace`, `terrapyne run`, etc. all exit 2 when showing help. Breaks shell scripts and `set -e` workflows.

---

## What changed

**Affected:** All 7 CLI command modules

Same fix as PR #9 for the root app — replace `no_args_is_help=True` (exits 2) with `invoke_without_command=True` callback (exits 0).

---

## Testing

289 tests pass. Verified: all 7 subcommands exit 0 when called without arguments.
