### PR TITLE
perf(project): use filter[names] for exact match in project find

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,3 +60,6 @@ slow commands and understanding what the tool is doing.
 Cache expensive API responses (workspace list, project list, team list) in
 `~/.cache/terrapyne/` with a configurable TTL (default 5min). Invalidate on any write
 operation. Would make repeated `tfc project show` or `tfc workspace list` near-instant.
+
+Other Findings
+- `terraform workspace show` - could show the project, last run status, health status

--- a/src/terrapyne/api/projects.py
+++ b/src/terrapyne/api/projects.py
@@ -41,9 +41,12 @@ class ProjectAPI:
 
         params = {}
         if search:
-            # Strip wildcards for API - TFC uses 'q' for substring search
-            search_term = search.replace("*", "")
-            params["q"] = search_term
+            if "*" in search:
+                # Wildcard → substring search (strip wildcards for API)
+                params["q"] = search.replace("*", "")
+            else:
+                # Exact name → use filter[names] for fast server-side match
+                params["filter[names]"] = search
 
         items_iterator, total_count = self.client.paginate_with_meta(path, params=params)
 

--- a/src/terrapyne/cli/project_cmd.py
+++ b/src/terrapyne/cli/project_cmd.py
@@ -110,7 +110,7 @@ def find_projects(
         sys.exit(0)
 
     # Get actual workspace counts
-    workspace_counts = project_api.get_workspace_counts(org)
+    workspace_counts: dict[str, int] = {}  # skip expensive count for find results
 
     render_projects(
         projects,

--- a/tests/unit/test_project_find_perf.py
+++ b/tests/unit/test_project_find_perf.py
@@ -1,0 +1,46 @@
+"""Test project find uses server-side filtering."""
+
+from unittest.mock import MagicMock
+
+from terrapyne.api.projects import ProjectAPI
+
+
+class TestProjectListFiltering:
+    def _make_client(self):
+        mock = MagicMock()
+        mock.get_organization.return_value = "test-org"
+        mock.paginate_with_meta.return_value = (iter([]), None)
+        return mock
+
+    def _get_params(self, client):
+        return client.paginate_with_meta.call_args.kwargs.get("params", {})
+
+    def test_exact_name_uses_filter_names(self):
+        """No wildcards → use filter[names] for exact server-side match."""
+        client = self._make_client()
+        api = ProjectAPI(client)
+        list(api.list("test-org", search="93126-MAN")[0])
+
+        params = self._get_params(client)
+        assert "filter[names]" in params
+        assert params["filter[names]"] == "93126-MAN"
+
+    def test_wildcard_uses_q_param(self):
+        """Wildcards → use q= for substring search."""
+        client = self._make_client()
+        api = ProjectAPI(client)
+        list(api.list("test-org", search="*-MAN")[0])
+
+        params = self._get_params(client)
+        assert "q" in params
+        assert "filter[names]" not in params
+
+    def test_no_search_sends_no_filter(self):
+        """No search → no filter params."""
+        client = self._make_client()
+        api = ProjectAPI(client)
+        list(api.list("test-org")[0])
+
+        params = self._get_params(client)
+        assert "q" not in params
+        assert "filter[names]" not in params


### PR DESCRIPTION
## Summary

`tfc project find 93126-MAN` drops from 1m38s to <1s by using server-side exact match.

---

## Why

**Driver:** Exploratory testing found `tfc project find 93126-MAN` takes 1m38s. The API was using `q=` (substring) which paginates through hundreds of partial matches. TFC supports `filter[names]` for exact match.

---

## What changed

**Affected:** src/terrapyne/api/projects.py, src/terrapyne/cli/project_cmd.py

- Exact names (no `*`) → `filter[names]` (single API call, exact match)
- Wildcards (`*-MAN`, `10234-*`) → `q=` (substring search, as before)
- `find_projects` skips `get_workspace_counts` (was adding another full-org scan)

---

## Testing

3 unit tests: exact name uses filter[names], wildcard uses q=, no search sends no filter.
374 tests pass.
