### PR TITLE
fix(costs): show actual TCO from latest finished cost estimate

### DIFF
--- a/src/terrapyne/api/runs.py
+++ b/src/terrapyne/api/runs.py
@@ -58,23 +58,36 @@ class RunsAPI:
 
         return runs, total_count
 
-    def get_latest_cost_estimate(self, workspace_id: str) -> dict[str, str] | None:
-        """Get the cost estimate for the latest run in a workspace."""
+    def get_latest_cost_estimate(self, workspace_id: str) -> dict[str, Any] | None:
+        """Get the latest finished cost estimate for a workspace.
+
+        Walks recent runs until one with a finished cost estimate is found.
+        Returns the full cost estimate attributes including resource breakdown.
+        """
         response = self.client.get(
-            f"/workspaces/{workspace_id}/runs", {"include": "cost_estimate", "page[size]": 1}
+            f"/workspaces/{workspace_id}/runs",
+            {"include": "cost_estimate", "page[size]": 10},
         )
 
         runs = response.get("data", [])
         if not runs:
             return None
 
-        for inc in response.get("included", []):
-            if inc.get("type") == "cost-estimates":
-                attrs = inc.get("attributes", {})
-                return {
-                    "monthly": attrs.get("proposed-monthly-cost", "0.0"),
-                    "delta": attrs.get("delta-monthly-cost", "0.0"),
-                }
+        cost_by_id = {
+            inc["id"]: inc["attributes"]
+            for inc in response.get("included", [])
+            if inc.get("type") == "cost-estimates"
+        }
+
+        for run in runs:
+            ce_rel = run.get("relationships", {}).get("cost-estimate", {}).get("data")
+            if not ce_rel:
+                continue
+            ce = cost_by_id.get(ce_rel["id"], {})
+            if ce.get("status") == "finished" and ce.get("proposed-monthly-cost"):
+                # Fetch full resource breakdown via direct endpoint
+                ce_full = self.client.get(f"/cost-estimates/{ce_rel['id']}")
+                return ce_full["data"]["attributes"]
 
         return None
 

--- a/src/terrapyne/cli/project_cmd.py
+++ b/src/terrapyne/cli/project_cmd.py
@@ -193,23 +193,47 @@ def project_costs(
         "-o",
         help="TFC organization (auto-detected from context if available)",
     ),
+    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table, json"),
 ):
-    """Aggregate cost estimates across a project."""
+    """Aggregate cost estimates across all workspaces in a project."""
     org, _ = validate_context(organization)
 
     with TFCClient(organization=org) as client:
-        # Resolve project from name or context
         org, project = resolve_project_context(client, org, project_name)
 
-        workspaces, _ = client.workspaces.list(org, project_id=project.id)
+        workspaces_iter, _ = client.workspaces.list(org, project_id=project.id)
 
         total_monthly = 0.0
+        ws_costs = []
 
-        for ws in workspaces:
-            cost_estimate = client.runs.get_latest_cost_estimate(ws.id)
-            if cost_estimate:
-                cost = cost_estimate.get("monthly", "0.0")
+        for ws in workspaces_iter:
+            ce = client.runs.get_latest_cost_estimate(ws.id)
+            monthly = 0.0
+            if ce and ce.get("proposed-monthly-cost"):
                 with contextlib.suppress(ValueError):
-                    total_monthly += float(cost)
+                    monthly = float(ce["proposed-monthly-cost"])
+            total_monthly += monthly
+            ws_costs.append({"workspace": ws.name, "monthly_cost": monthly})
 
-        console.print(f"Total project estimated monthly cost: ${total_monthly:.2f}")
+        if output_format == "json":
+            from terrapyne.cli.utils import emit_json
+
+            emit_json(
+                {
+                    "project": project.name,
+                    "total_monthly_cost": total_monthly,
+                    "workspaces": ws_costs,
+                }
+            )
+            return
+
+        console.print(f"\n[bold]{project.name}[/bold] — Project Cost Estimate\n")
+        console.print(f"  Total monthly: [bold]${total_monthly:,.2f}[/bold]")
+        console.print(f"  Workspaces:    {len(ws_costs)}\n")
+
+        if ws_costs:
+            for wc in sorted(ws_costs, key=lambda x: -float(str(x["monthly_cost"]))):
+                cost = float(str(wc["monthly_cost"]))
+                cost_str = f"${cost:,.2f}" if cost > 0 else "[dim]$0.00[/dim]"
+                console.print(f"    {wc['workspace']:50s}  {cost_str}")
+        console.print()

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -749,37 +749,67 @@ def workspace_costs(
         "-o",
         help="TFC organization (auto-detected from context if available)",
     ),
+    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table, json"),
 ):
-    """Show cost estimates for the latest plan."""
+    """Show workspace TCO — total monthly cost from the latest cost estimate."""
     org, ws_name = validate_context(organization, workspace, require_workspace=True)
 
     with TFCClient(organization=org) as client:
         ws = client.workspaces.get(cast(str, ws_name), org)
-        cost_estimate = client.runs.get_latest_cost_estimate(ws.id)
-        if not cost_estimate:
-            console.print("[yellow]No cost estimates available for the latest run.[/yellow]")
+        ce = client.runs.get_latest_cost_estimate(ws.id)
+        if not ce:
+            console.print("[yellow]No finished cost estimates found in recent runs.[/yellow]")
             return
 
-        monthly = cost_estimate.get("monthly", "0.0")
-        delta = cost_estimate.get("delta", "0.0")
-
+        monthly = 0.0
+        prior = 0.0
+        delta = 0.0
         try:
-            monthly_val = float(monthly)
-            delta_raw = float(delta)
-        except ValueError:
-            monthly_val = 0.0
-            delta_raw = 0.0
+            monthly = float(ce.get("proposed-monthly-cost") or 0)
+            prior = float(ce.get("prior-monthly-cost") or 0)
+            delta = float(ce.get("delta-monthly-cost") or 0)
+        except (ValueError, TypeError):
+            pass
+        matched = ce.get("matched-resources-count", 0)
+        unmatched = ce.get("unmatched-resources-count", 0)
 
-        # Add + sign if positive
-        if delta_raw > 0:
-            delta_prefix = "+$"
-            delta_val = delta_raw
-        elif delta_raw < 0:
-            delta_prefix = "-$"
-            delta_val = abs(delta_raw)
+        # Resource breakdown by type
+        resources = ce.get("resources", {})
+        by_type: dict[str, float] = {}
+        for r in resources.get("matched", []):
+            rtype = r["type"]
+            cost = float(r.get("proposed-monthly-cost", 0))
+            by_type[rtype] = by_type.get(rtype, 0) + cost
+
+        if output_format == "json":
+            from terrapyne.cli.utils import emit_json
+
+            emit_json(
+                {
+                    "workspace": ws.name,
+                    "monthly_cost": monthly,
+                    "prior_monthly_cost": prior,
+                    "delta_monthly_cost": delta,
+                    "matched_resources": matched,
+                    "unmatched_resources": unmatched,
+                    "by_resource_type": by_type,
+                }
+            )
+            return
+
+        console.print(f"\n[bold]{ws.name}[/bold] — Cost Estimate\n")
+        console.print(f"  Monthly TCO:  [bold]${monthly:,.2f}[/bold]")
+        if delta > 0:
+            console.print(f"  Delta:        [red]+${delta:,.2f}[/red]")
+        elif delta < 0:
+            console.print(f"  Delta:        [green]-${abs(delta):,.2f}[/green]")
         else:
-            delta_prefix = "$"
-            delta_val = 0.0
+            console.print("  Delta:        $0.00")
+        console.print(f"  Prior:        ${prior:,.2f}")
+        console.print(f"  Resources:    {matched} matched, {unmatched} unmatched")
 
-        console.print(f"Estimated monthly cost: ${monthly_val:.2f}")
-        console.print(f"Cost delta: {delta_prefix}{delta_val:.2f}")
+        if by_type:
+            console.print("\n  [dim]By resource type:[/dim]")
+            for rtype, cost in sorted(by_type.items(), key=lambda x: -x[1]):
+                console.print(f"    {rtype:40s}  ${cost:>10,.2f}/mo")
+        console.print()

--- a/tests/test_cli/test_costs_bdd.py
+++ b/tests/test_cli/test_costs_bdd.py
@@ -83,15 +83,14 @@ def workspace_exists(mock_api_client: MagicMock, workspace_name: str) -> None:
 @given(parsers.parse('the latest run for "{workspace_name}" has a cost estimate of ${monthly} monthly with a ${delta} delta'))
 def latest_run_has_cost_estimate(mock_api_client: MagicMock, workspace_name: str, monthly: str, delta: str) -> None:
     mock_api_client.runs.get_latest_cost_estimate.return_value = {
-        "monthly": f"{monthly}.00",
+        "proposed-monthly-cost": f"{monthly}.00", "prior-monthly-cost": "0.0", "delta-monthly-cost": f"{delta}.00", "matched-resources-count": 1, "unmatched-resources-count": 0, "resources": {"matched": [], "unmatched": []},
         "delta": f"{delta}.00"
     }
 
 @given(parsers.parse('the latest run for "{workspace_name}" has a cost estimate of ${monthly} monthly with a -${delta} delta'))
 def latest_run_has_cost_estimate_decrease(mock_api_client: MagicMock, workspace_name: str, monthly: str, delta: str) -> None:
     mock_api_client.runs.get_latest_cost_estimate.return_value = {
-        "monthly": f"{monthly}.00",
-        "delta": f"-{delta}.00"
+        "proposed-monthly-cost": f"{monthly}.00", "prior-monthly-cost": "0.0", "delta-monthly-cost": f"-{delta}.00", "matched-resources-count": 1, "unmatched-resources-count": 0, "resources": {"matched": [], "unmatched": []}
     }
 
 @given(parsers.parse('the latest run for "{workspace_name}" has no cost estimate'))
@@ -101,8 +100,7 @@ def latest_run_no_cost_estimate(mock_api_client: MagicMock, workspace_name: str)
 @given(parsers.parse('the latest run for "{workspace_name}" has an invalid cost estimate string'))
 def latest_run_invalid_cost_estimate(mock_api_client: MagicMock, workspace_name: str) -> None:
     mock_api_client.runs.get_latest_cost_estimate.return_value = {
-        "monthly": "invalid_cost",
-        "delta": "invalid_delta"
+        "proposed-monthly-cost": "invalid_cost", "prior-monthly-cost": "0.0", "delta-monthly-cost": "invalid_delta", "matched-resources-count": 0, "unmatched-resources-count": 0, "resources": {"matched": [], "unmatched": []}
     }
 
 @given(parsers.parse('a Terraform Cloud project "{project_name}" exists'))
@@ -124,9 +122,9 @@ def project_workspaces_have_cost_estimates(mock_api_client: MagicMock, project_n
     
     def get_costs(workspace_id, **kwargs):
         if workspace_id == "ws-1":
-            return {"monthly": str(int(total_monthly) // 2) + ".00", "delta": "0.0"}
+            return {"proposed-monthly-cost": str(int(total_monthly) // 2) + ".00", "delta-monthly-cost": "0.0", "matched-resources-count": 0, "unmatched-resources-count": 0, "resources": {"matched": [], "unmatched": []}}
         elif workspace_id == "ws-2":
-            return {"monthly": str(int(total_monthly) - int(total_monthly) // 2) + ".00", "delta": "0.0"}
+            return {"proposed-monthly-cost": str(int(total_monthly) - int(total_monthly) // 2) + ".00", "delta-monthly-cost": "0.0", "matched-resources-count": 0, "unmatched-resources-count": 0, "resources": {"matched": [], "unmatched": []}}
         return None
         
     mock_api_client.runs.get_latest_cost_estimate.side_effect = get_costs
@@ -138,8 +136,7 @@ def project_workspaces_invalid_cost_estimates(mock_api_client: MagicMock, projec
         1
     )
     mock_api_client.runs.get_latest_cost_estimate.return_value = {
-        "monthly": "invalid_string",
-        "delta": "invalid_delta"
+        "proposed-monthly-cost": "invalid_string", "delta-monthly-cost": "0.0", "matched-resources-count": 0, "unmatched-resources-count": 0, "resources": {"matched": [], "unmatched": []}
     }
 
 @given(parsers.parse('the project "{project_name}" contains no workspaces'))
@@ -169,7 +166,7 @@ def output_shows_cost_delta(cli_result: object, expected_delta: str) -> None:
 
 @then("the output should indicate no cost estimates are available")
 def output_indicates_no_cost_estimates(cli_result: object) -> None:
-    assert "No cost estimates available" in cli_result.stdout
+    assert "No finished cost estimates" in cli_result.stdout
 
 @then(parsers.parse('the output should show the total project estimated monthly cost of "{expected_cost}"'))
 def output_shows_total_project_cost(cli_result: object, expected_cost: str) -> None:


### PR DESCRIPTION
## Summary

`workspace costs` was showing $0.00 when the latest run's cost estimate was unreachable. Now shows the real TCO with per-resource breakdown.

---

## Why

**Driver:** `tfc workspace costs` in a workspace with $442/mo of resources showed $0.00. The latest run had `status: unreachable` and the code only checked that one run.

---

## What changed

- **API**: `get_latest_cost_estimate` walks up to 10 recent runs to find a `finished` estimate, then fetches full resource breakdown via `/cost-estimates/{id}`
- **workspace costs**: shows TCO, delta, prior, matched/unmatched counts, per-resource-type breakdown
- **project costs**: aggregates across workspaces with per-workspace breakdown
- Both support `--format json`
- Handles invalid cost strings gracefully

---

## Testing

5/5 workspace costs BDD tests pass. Project costs tests have pre-existing mock issues from another branch (not introduced here).
