### PR TITLE
docs(agent-instructions): add lean AGENTS.md and development guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# Terrapyne Agent Instructions
+
+A Python CLI wrapper around Terraform Cloud with a focus on clean code, lean principles, and test-driven development.
+
+## Quick Start
+
+```bash
+uv sync                         # Install dependencies (includes dev)
+uv run pytest                   # Run all tests (target: 65% coverage)
+uv run ruff check . && uv run ruff format .  # Lint and format
+uv run mypy src/                # Type check
+```
+
+## Core Principles
+
+- **Red/Green TDD**: Write failing tests first, minimal implementation, then refactor
+- **Adzic BDD**: Feature files use Gojko Adzic's Specification by Example (outcome-focused, not implementation-scripted)
+- **Atomic Commits**: Every commit is verified, self-contained, uses Conventional Commits
+- **No AI Markers**: Never add co-author or AI attribution to code, commits, docs, or PR descriptions
+
+## Development Guides
+
+Detailed conventions and patterns:
+- [Python & Testing](docs/guides/python-and-testing.md) — Type hints, imports, test structure, pytest-bdd
+- [BDD Specifications](docs/guides/bdd-specifications.md) — Writing Adzic-aligned feature files and step definitions
+- [Commits & Review](docs/guides/commits-and-review.md) — Atomic commits, conventional format, PR process
+- [Architecture](docs/architecture/) — ADRs, design decisions, model patterns
+
+## Essential Skills
+
+Use these skills to stay aligned:
+
+| Skill | When to Use |
+|-------|------------|
+| [git](~/.claude/skills/git/) | Before any git operation — read safety guardrails |
+| [adzic-index](~/.claude/skills/adzic-index/) | Evaluating BDD feature file quality against spec principles |
+| [farley-index](~/.claude/skills/farley-index/) | Auditing test suite health: fast, honest, necessary, maintainable, atomic, repeatable |
+| [test-accordion](~/.claude/skills/test-accordion/) | Expanding/contracting test scope in elastic loop during TDD |
+| [using-git-worktrees](~/.claude/skills/using-git-worktrees/) | Creating isolated feature branches with worktrees |
+| [commit](~/.claude/skills/commit/) | Crafting atomic, verified commits before pushing |
+
+## Project Structure
+
+```
+src/terrapyne/
+├── cli/          # Typer CLI commands (workspace, run, state, project, etc.)
+├── api/          # TFCClient and API abstractions
+├── models/       # Pydantic models (Run, Workspace, StateVersion, etc.)
+├── core/         # Parsing and core utilities
+└── sdk/          # High-level SDK interface
+
+tests/
+├── test_cli/     # pytest-bdd step definitions and assertions
+├── test_unit/    # Unit tests for models and utilities
+├── features/     # Gherkin feature files (.feature)
+└── conftest.py   # Shared fixtures
+```
+
+## Testing Patterns
+
+**BDD (pytest-bdd):**
+- Feature files describe business outcomes: `tests/features/*.feature`
+- Step definitions in `tests/test_cli/test_*_bdd.py`
+- Use `@given/@when/@then` decorators with parsers
+- Mock at TFCClient level, not httpx
+- Assert outcomes (e.g., "active run count visible"), not implementation (e.g., "emoji 🟢 present")
+
+**Unit Tests:**
+- Models and utilities in `tests/test_unit/`
+- Use fixtures and mocks (`Mock(spec=...)` for type safety)
+- Fast, deterministic, no I/O
+
+**Coverage:**
+- Minimum 65% across `src/terrapyne/`
+- Run: `pytest --cov=terrapyne --cov-report=html`
+
+## Code Quality
+
+**Ruff (linting & formatting):**
+```bash
+ruff check . && ruff format .
+```
+- Line length: 100 chars
+- Target: Python 3.12+
+- Rules: E, F, I, B, PL, RUF (see `pyproject.toml` for exceptions)
+
+**MyPy (type checking):**
+```bash
+mypy src/
+```
+- Strict mode enabled where possible
+- Document any `# type: ignore` with reason
+
+**Pre-commit hooks:**
+- Ruff, MyPy, and test coverage validation run automatically
+- Fix issues before pushing
+
+## Commits & PRs
+
+- **Format**: Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
+- **Scope**: Single responsibility per commit (atomic)
+- **Message**: Describe *why*, not *what* (the diff shows what)
+- **Verification**: All commits pass tests, linting, type checks
+- **Skill**: Use `/commit` skill to craft safe, verified commits
+
+See [Commits & Review Guide](docs/guides/commits-and-review.md) for details.
+
+## Development Workflow
+
+1. Create a worktree for isolated work:
+   ```bash
+   # Skill: using-git-worktrees
+   git worktree add .claude/worktrees/feature-name
+   ```
+
+2. Write failing test first (Red):
+   - Feature file (BDD) or test function (unit)
+   - Use `pytest -k <test>` to focus
+
+3. Make test pass (Green):
+   - Minimal implementation, no over-engineering
+   - Run tests frequently: `pytest --tb=short`
+   - Use `test-accordion` skill to expand/contract scope
+
+4. Refactor (optional):
+   - Only if code clarity improves
+   - Re-run tests; ensure coverage stable
+
+5. Commit & push:
+   - Use `/commit` skill for safe, verified commits
+   - Push creates PR (with clear description linking to ADRs/issues)
+
+6. Review & merge:
+   - Code review focuses on intent, not style
+   - Ensure no AI markers in code/commits
+
+## Continuous Integration
+
+**Pre-commit checks:**
+- Ruff (linting, formatting)
+- MyPy (type checking)
+- Test coverage (≥65%)
+
+**All commits must pass locally before pushing** — no fix-up commits.
+
+## Getting Help
+
+- Architecture decisions: See `docs/architecture/ADR-*.md`
+- Testing strategy: See ADR-004 and [BDD Specifications guide](docs/guides/bdd-specifications.md)
+- Python patterns: See [Python & Testing guide](docs/guides/python-and-testing.md)
+- Git safety: Use `/git` skill before any operation
+
+---
+
+**Note:** This project enforces clean code and lean principles. Challenge vague requirements; propose alternatives before implementing. No speculative features.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,43 @@
+# Development Guides
+
+Detailed conventions and workflows for Terrapyne development.
+
+## Quick Links
+
+- **[Python & Testing](python-and-testing.md)** — Type hints, imports, test structure, pytest-bdd patterns
+- **[BDD Specifications](bdd-specifications.md)** — Writing Adzic-aligned feature files and step definitions
+- **[Commits & Review](commits-and-review.md)** — Atomic commits, conventional format, PR workflow
+
+## For Agents
+
+Start with the relevant guide based on your task:
+
+| Task | Guide |
+|------|-------|
+| Writing tests or features | [BDD Specifications](bdd-specifications.md) + [Python & Testing](python-and-testing.md) |
+| Python code (models, CLI, utils) | [Python & Testing](python-and-testing.md) |
+| Creating commits or PRs | [Commits & Review](commits-and-review.md) |
+| Understanding project structure | [AGENTS.md](../../AGENTS.md) + architecture in `docs/architecture/` |
+
+## Skills to Use
+
+These guides link to Claude Code skills:
+- **adzic-index** — Audit BDD feature file quality
+- **farley-index** — Audit test suite health
+- **test-accordion** — Expand/contract test scope elastically
+- **git** — Safety guardrails before git operations
+- **commit** — Craft safe, verified commits
+- **using-git-worktrees** — Create isolated feature branches
+
+See [AGENTS.md](../../AGENTS.md) for skill details.
+
+## Development Workflow
+
+1. Create a worktree: `/using-git-worktrees`
+2. Write failing test (Red): Feature file or unit test
+3. Make it pass (Green): Minimal implementation
+4. Refactor (optional): Improve clarity
+5. Commit: `/commit` skill
+6. Push & create PR
+
+See [Commits & Review](commits-and-review.md) for detailed workflow.

--- a/docs/guides/bdd-specifications.md
+++ b/docs/guides/bdd-specifications.md
@@ -1,0 +1,238 @@
+# BDD Specifications Guide
+
+Writing Adzic-aligned feature files and step definitions using pytest-bdd.
+
+## Specification by Example (Adzic Principles)
+
+BDD tests focus on *business outcomes*, not implementation details. Feature files are living documentation that stakeholders can read and validate.
+
+### The Six Dimensions (Adzic Index)
+
+| Dimension | Question | Good | Avoid |
+|-----------|----------|------|-------|
+| **Business-Readable** | Would a non-technical stakeholder understand this? | "Workspace shows health status" | "Check if emoji renders" |
+| **Intention-Revealing** | Does the scenario explain *why* the feature exists? | "I want to see active runs so I can prioritize my work" | "Test run listing" |
+| **Living** | Is the scenario executable? | All steps have implementations | @pending scenarios at ship |
+| **Declarative** | Does it describe *what*, not *how*? | "I should see run count" | "Click on 'Runs' tab, verify cell 3" |
+| **Focused** | Does each scenario test one behavior? | One scenario per user story | Multiple features per scenario |
+| **Atomic** | Can the scenario run independently? | No shared state between scenarios | Tests depend on execution order |
+
+## Writing Feature Files
+
+**Location:** `tests/features/*.feature`
+
+**Template:**
+```gherkin
+Feature: [Feature Name]
+  As a [user role]
+  I want to [action/capability]
+  So that [business value]
+
+  Background:
+    Given [prerequisite setup needed by all scenarios]
+
+  Scenario: [Specific user story / business outcome]
+    Given [initial state]
+    When [user action]
+    Then [expected result]
+    And [additional assertions]
+
+  Scenario: [Another specific outcome]
+    Given [different initial state]
+    When [different action]
+    Then [different expected result]
+```
+
+**Good example:**
+```gherkin
+Feature: Workspace Activity Dashboard
+  As a DevOps engineer
+  I want to see a health and activity summary when I inspect a workspace
+  So that I can assess its state without opening the GUI
+
+  Scenario: Workspace with recent successful run shows healthy status
+    Given a workspace with a recently applied run
+    When I show the workspace details
+    Then I should see the workspace health snapshot
+    And I should see the active run count
+
+  Scenario: Workspace with no run history shows unknown health
+    Given a workspace with no runs
+    When I show the workspace details
+    Then I should see unknown health status
+    And I should see zero active runs
+```
+
+**Avoid:**
+```gherkin
+Feature: Test workspace commands
+  # Why? Vague; doesn't explain business value
+
+  Scenario: Workspace show test
+    # Why? Vague action/outcome
+    Given I set up a workspace context
+    When I invoke the workspace show CLI command
+    Then the exit code should be 0
+    And the output should contain workspace name in the correct column format
+    # Why? Implementation-scripted; tests UI, not business outcome
+```
+
+### Scenario Guidelines
+
+| Do | Reason | Example |
+|----|--------|---------|
+| Use present tense | Reads naturally | "When I show the workspace" (not "showed") |
+| Use "I" for user actions | Empathy; first-person perspective | "I should see" (not "user should see") |
+| Describe outcomes, not steps | Business-focused | "health snapshot is visible" (not "emoji 🟢 renders") |
+| One assertion per Then | Clear pass/fail | "Then I should see health status" |
+| Use tables for data | Readable examples | `\| aws_instance.web \|` |
+| Use concrete values | Testable | "workspace my-app-dev" (not "a workspace") |
+
+## Writing Step Definitions
+
+**Location:** `tests/test_cli/test_*_bdd.py`
+
+**Pattern:**
+```python
+from pytest_bdd import given, scenario, then, when, parsers
+from unittest.mock import patch, MagicMock
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+# Scenario wrapper
+@scenario("../features/workspace.feature", "Workspace with recent successful run shows healthy status")
+def test_dashboard_healthy():
+    pass
+
+# Given: Setup (not a fixture)
+@given("a workspace with a recently applied run")
+def workspace_with_recent_run():
+    """Establish initial state; does not execute CLI."""
+    pass
+
+# When: Action (fixture returning context)
+@pytest.fixture
+@when("I show the workspace details")
+def show_workspace_details(workspace_detail_response, run_list_response):
+    """Execute the CLI command and capture output."""
+    with patch("terrapyne.cli.workspace_cmd.TFCClient") as mock_client:
+        mock_instance = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_instance
+        
+        workspace = Workspace.from_api_response(workspace_detail_response["data"])
+        runs = [Run.from_api_response(data) for data in run_list_response["data"]]
+        
+        mock_instance.workspaces.get.return_value = workspace
+        mock_instance.runs.list.return_value = (runs, len(runs))
+        
+        result = runner.invoke(app, ["workspace", "show", "my-app-dev", "--organization", "test-org"])
+        
+        return {"result": result, "workspace": workspace, "runs": runs}
+
+# Then: Assertions (outcome-focused)
+@then("I should see the workspace health snapshot")
+def check_health_snapshot(show_workspace_details):
+    """Verify health information is present."""
+    result = show_workspace_details["result"]
+    assert result.exit_code == 0, f"Command failed: {result.stdout}"
+    
+    # Outcome: health status is visible
+    output_lower = result.stdout.lower()
+    assert any(
+        keyword in output_lower
+        for keyword in ["health", "status", "snapshot", "state"]
+    ), "Health snapshot not found in output"
+```
+
+### Mocking Strategy
+
+**Mock at TFCClient level, not httpx:**
+```python
+# ✅ GOOD: Mock the high-level client
+with patch("terrapyne.cli.workspace_cmd.TFCClient") as mock_client:
+    mock_instance = MagicMock()
+    mock_client.return_value.__enter__.return_value = mock_instance
+    mock_instance.workspaces.get.return_value = workspace
+    # Now test the CLI command
+
+# ❌ AVOID: Mocking httpx directly
+with patch("httpx.Client") as mock_http:
+    # Hard to maintain, tightly coupled to implementation
+```
+
+**Use `Mock(spec=...)` for type safety:**
+```python
+# ✅ GOOD: IDE autocomplete, catches typos
+mock_run = Mock(spec=Run)
+mock_run.status = RunStatus.APPLIED
+mock_run.id = "run-abc123"
+
+# ❌ AVOID: No type safety
+mock_run = MagicMock()
+mock_run.status = RunStatus.APPLIED
+```
+
+### Assertion Guidelines
+
+| Outcome-Focused | Implementation-Scripted | Why Prefer |
+|-----------------|------------------------|-----------|
+| "I should see active run count" | "Check if cell contains count" | Tests behavior, not UI |
+| "Health status is visible" | "Emoji 🟢 is present" | Resilient to design changes |
+| "Commit SHA is displayed" | "Substring matches 40 hex chars" | Focuses on outcome |
+| "Output is valid JSON" | "JSON has 'snapshot' key at level 3" | Less brittle |
+
+**Good example:**
+```python
+@then("I should see the latest run information")
+def check_latest_run_info(show_workspace_dashboard):
+    result = show_workspace_dashboard["result"]
+    runs = show_workspace_dashboard["runs"]
+    
+    assert result.exit_code == 0
+    # Outcome: latest run is present in output
+    if runs:
+        latest_run = runs[0]
+        assert (
+            latest_run.id in result.stdout
+            or "run" in result.stdout.lower()
+        ), "Latest run information not found"
+```
+
+## Feature File Checklist
+
+Before committing a feature file:
+
+- [ ] User persona is clear (who is the actor?)
+- [ ] Business value is stated (why does this matter?)
+- [ ] Scenario titles are specific (not generic "test X")
+- [ ] Each Given/When/Then is a complete sentence
+- [ ] No implementation details (buttons, exact text, emoji)
+- [ ] Scenarios are independent (can run in any order)
+- [ ] All steps have implementations (no orphaned steps)
+- [ ] Coverage includes happy path, error cases, edge cases
+
+## Evaluating BDD Quality
+
+Use the `adzic-index` skill to audit feature files:
+```bash
+# In Claude Code:
+/adzic-index tests/features/workspace.feature
+```
+
+This scores your feature file on:
+- Business-Readable: Would stakeholders understand?
+- Intention-Revealing: Does intent shine through?
+- Living: Are all steps executable?
+- Declarative: Is it outcome-focused?
+- Focused: One behavior per scenario?
+- Atomic: Can scenarios run independently?
+
+Target: **≥7.0/10** for release-ready features.
+
+## Related Resources
+
+- [ADR-004: Workspace Dashboard Testing Strategy](../architecture/ADR-004-workspace-dashboard-testing.md)
+- [Python & Testing Guide](python-and-testing.md)
+- Gojko Adzic: [Specification by Example](https://gojko.net/2014/02/07/building-a-specification-framework/)
+- pytest-bdd: [Documentation](https://pytest-bdd.readthedocs.io/)

--- a/docs/guides/commits-and-review.md
+++ b/docs/guides/commits-and-review.md
@@ -1,0 +1,281 @@
+# Commits & Review Guide
+
+Atomic commits, conventional formats, and PR process for Terrapyne.
+
+## Atomic Commit Protocol (ACP)
+
+Every commit is:
+- **Self-contained**: Solves one problem, stands alone
+- **Verified**: Passes tests, linting, type checks locally before push
+- **Meaningful**: Clear commit message explains *why*
+
+### Commit Message Format
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Type:** `feat`, `fix`, `docs`, `test`, `refactor`, `chore`
+**Scope:** Optional; affected area (e.g., `workspace-cmd`, `run-model`, `cli`)
+**Subject:** Imperative, present tense, lowercase, no period, ≤50 chars
+
+**Good examples:**
+```
+feat(workspace-cmd): show health status in workspace snapshot
+
+fix(runs): prevent Run ID truncation in table output
+
+test(workspace-dashboard): add BDD scenarios for activity snapshot
+
+docs(adr): add ADR-004 for workspace dashboard testing strategy
+
+refactor(api-client): consolidate workspace_show API calls
+
+chore: update pytest to 8.0.0
+```
+
+**Bad examples:**
+```
+feat: Added workspace health status    # Vague scope, past tense
+Fixed bug in run display               # Missing type
+WIP: workspace changes                 # No type/scope
+Update dependencies                    # No meaningful detail
+```
+
+### Commit Body
+
+Explain *why* the change matters, not *what* changed (the diff shows that).
+
+**Example:**
+```
+feat(workspace-cmd): show health status in workspace snapshot
+
+The workspace show command now displays a health and activity summary 
+including latest run status, active run count, and VCS metadata. This 
+gives DevOps engineers a quick assessment without opening the GUI.
+
+- Fetch last 20 runs in single API call (reduces latency)
+- Determine health from latest run status
+- Display commit metadata if run is VCS-linked
+- JSON output includes snapshot section for IDP integration
+
+Closes #42
+Relates to ADR-001 (Workspace Dashboard Architecture)
+```
+
+### Commit Size
+
+- **Too small**: "Add import statement" (combine with feature commit)
+- **Too large**: Multiple unrelated features (split them)
+- **Right size**: One logical unit that could be reverted independently
+
+**Test:** If your commit message uses "and" more than once, it's probably too large.
+
+## Using the `/commit` Skill
+
+Before pushing, use the `/commit` skill to craft safe, verified commits:
+
+```bash
+# In Claude Code:
+/commit
+```
+
+The skill:
+1. Runs `git status` to see changes
+2. Runs `git diff` to review staged changes
+3. Runs `git log` to follow the repo's commit style
+4. Drafts a commit message
+5. Creates the commit (verifying tests pass)
+6. Runs `git status` to confirm
+
+**Never skip the skill** — it's your safety net against bad commits.
+
+## Pre-Push Checklist
+
+Before `git push`:
+
+```bash
+# 1. Run tests (all must pass)
+uv run pytest
+
+# 2. Check coverage (≥65%)
+uv run pytest --cov=terrapyne --cov-fail-under=65
+
+# 3. Lint and format
+uv run ruff check . && uv run ruff format .
+
+# 4. Type check
+uv run mypy src/
+
+# 5. Review commits locally
+git log origin/main..HEAD --oneline
+
+# 6. Ensure no AI markers in code/commits
+grep -r "Co-Authored-By\|claude\|openai" src/ tests/  # Should be empty
+```
+
+All must pass before pushing.
+
+## Pull Request Process
+
+1. **Create worktree** for isolated work:
+   ```bash
+   # Use /using-git-worktrees skill
+   git worktree add .claude/worktrees/feature-name
+   ```
+
+2. **Write tests first** (Red/Green TDD):
+   - Feature file (BDD) or unit test
+   - Should fail initially
+   - Implement minimal code to pass
+
+3. **Commit frequently**:
+   - One atomic commit per logical unit
+   - Use `/commit` skill for safety
+   - All tests pass locally
+
+4. **Push and create PR**:
+   ```bash
+   git push -u origin feature-branch
+   # GitHub creates PR with branch name as title
+   ```
+
+5. **PR Description** (auto-filled with git commits):
+   - Summary: 1-3 bullet points of impact
+   - Test plan: How reviewers should verify
+   - Links: Related ADRs, issues, related PRs
+   - **No AI markers** (no "Co-Authored-By", no "Claude Code", no "AI-generated")
+
+   **Example:**
+   ```
+   ## Summary
+   - Workspace show command now displays health snapshot
+   - Reduces API calls by combining run fetch into single request
+   - Enables IDP integration via JSON output
+
+   ## Test Plan
+   - [ ] Run `pytest tests/test_cli/test_workspace_dashboard_bdd.py`
+   - [ ] Manual: `terrapyne workspace show my-app-dev`
+   - [ ] Verify JSON output includes snapshot section
+
+   Related: ADR-001 (Workspace Dashboard Architecture)
+   ```
+
+6. **Review & merge**:
+   - Code review focuses on intent, clarity, adherence to patterns
+   - Style issues caught by pre-commit hooks (not manual review)
+   - Merge to `main` when approved
+
+## Branch Naming
+
+```
+feat/<feature-name>           # New feature
+fix/<issue-name>              # Bug fix
+docs/<doc-name>               # Documentation
+refactor/<area-name>          # Refactoring
+test/<test-name>              # Test coverage
+chore/<maintenance-task>      # Maintenance
+```
+
+**Good examples:**
+```
+feat/workspace-health-snapshot
+fix/run-id-truncation
+docs/bdd-specifications
+refactor/api-client-consolidation
+test/workspace-dashboard-bdd
+```
+
+## Code Review Checklist
+
+Reviewers should verify:
+
+- [ ] All tests pass (CI green)
+- [ ] Coverage ≥65% (or improved from before)
+- [ ] Type checks pass (`mypy`)
+- [ ] Linting passes (`ruff`)
+- [ ] Commit messages are clear and follow conventions
+- [ ] No AI markers in code or commits
+- [ ] Feature aligns with related ADRs
+- [ ] BDD scenarios are outcome-focused (if applicable)
+- [ ] No speculative features (only what was requested)
+
+## After Merge
+
+1. **Delete worktree**:
+   ```bash
+   git worktree remove .claude/worktrees/feature-name
+   ```
+
+2. **Close related issues** (via PR comment or GitHub automation)
+
+3. **Update documentation** if needed:
+   - ADRs if architectural decision changed
+   - TODO.md if discovery findings apply
+   - Contributing guides if new patterns introduced
+
+## Common Patterns
+
+### Squashing Commits Before Merge
+
+If review feedback requires changes:
+```bash
+# Make fixes
+git add .
+git commit -m "fix: address review feedback"
+
+# Squash with previous commit (if related)
+git rebase -i origin/main
+# Mark second commit as 'squash'
+# Update commit message if needed
+git push --force-with-lease
+```
+
+### Splitting a Commit
+
+If a commit is too large:
+```bash
+git rebase -i origin/main
+# Mark commit as 'edit'
+git reset HEAD~1
+# Stage parts selectively
+git add <file1>
+git commit -m "feat: part 1"
+git add <file2>
+git commit -m "feat: part 2"
+git rebase --continue
+```
+
+### Reverting a Merge
+
+If a PR causes issues after merge:
+```bash
+git revert -m 1 <merge-commit-hash>
+git push
+```
+
+Creates a new commit that undoes the merge (safe; preserves history).
+
+## Git Safety
+
+**Always use the `/git` skill before any git operation:**
+```bash
+# In Claude Code:
+/git  # Read safety guardrails
+```
+
+Key rules:
+- Never `git push --force` to `main`
+- Never skip hooks (`--no-verify`)
+- Never run `git reset --hard` without understanding consequences
+- Use `--force-with-lease` instead of `--force` to push safer
+
+---
+
+**Remember:** Every commit is a record of the project's evolution. Take care in crafting them — your future self (and teammates) will thank you.

--- a/docs/guides/python-and-testing.md
+++ b/docs/guides/python-and-testing.md
@@ -1,0 +1,254 @@
+# Python & Testing Guide
+
+Conventions for Python code, typing, imports, and test structure in Terrapyne.
+
+## Python Conventions
+
+### Type Hints
+
+- Always use type hints on function signatures
+- Use `from typing import` for complex types (Optional, Union, List, etc.)
+- Pydantic models for data validation; leverage `model_construct()` for performance when validation is skipped intentionally
+- Document `# type: ignore` with reason when necessary
+
+**Good:**
+```python
+def get_workspace(self, workspace_id: str) -> Workspace:
+    """Fetch workspace by ID."""
+    ...
+
+def list_runs(self, workspace_id: str, limit: int = 20) -> tuple[list[Run], int]:
+    """List runs; returns (runs, total_count)."""
+    ...
+```
+
+**Avoid:**
+```python
+def get_workspace(workspace_id):  # Missing type hints
+    ...
+
+def list_runs(workspace_id, limit=20):  # Missing return type
+    ...
+```
+
+### Imports
+
+- Group imports: stdlib, third-party, local (per isort/ruff conventions)
+- Use absolute imports (`from terrapyne.models import Run`)
+- Lazy imports for circular dependencies; document why
+- No wildcard imports (`from module import *`)
+
+**Good:**
+```python
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+from typer import Option
+
+from terrapyne.models.run import Run
+```
+
+### Naming
+
+- Constants: `UPPER_SNAKE_CASE`
+- Functions/methods: `lower_snake_case`
+- Classes: `PascalCase`
+- Private: prefix with `_` (e.g., `_internal_method`)
+- Enums: `PascalCase` class, `UPPER_SNAKE_CASE` members (e.g., `RunStatus.PENDING`)
+
+### Docstrings
+
+Add docstrings to public functions and classes:
+- One-liner describing the function
+- Args and Returns sections if not obvious from type hints
+- Example usage for non-obvious behavior
+
+**Good:**
+```python
+def get_active_runs(self, workspace_id: str) -> list[Run]:
+    """Fetch runs in active states (pending, running, awaiting_decision).
+    
+    Args:
+        workspace_id: Workspace identifier
+        
+    Returns:
+        List of runs in active states, ordered by creation time (newest first)
+    """
+    ...
+```
+
+## Test Structure
+
+### BDD Tests (Feature Files + Step Definitions)
+
+BDD tests verify end-to-end behavior using Gherkin scenarios.
+
+**Feature file** (`tests/features/workspace.feature`):
+```gherkin
+Feature: Workspace Management
+  As a DevOps engineer
+  I want to list and inspect workspaces
+  So that I can understand their configuration and health
+
+  Scenario: List all workspaces in organization
+    Given I have organization "test-org" set up
+    When I list all workspaces
+    Then I should see workspace list
+    And the list should show workspace count
+```
+
+**Step definitions** (`tests/test_cli/test_workspace_commands.py`):
+```python
+from uv run pytest_bdd import given, when, then, scenario
+from unittest.mock import patch, MagicMock
+
+@scenario("../features/workspace.feature", "List all workspaces in organization")
+def test_list_workspaces():
+    pass
+
+@given('I have organization "test-org" set up')
+def org_setup():
+    return {"org": "test-org"}
+
+@uv run pytest.fixture
+@when("I list all workspaces")
+def list_all_workspaces(org_setup, workspace_list_response):
+    with patch("terrapyne.cli.workspace_cmd.TFCClient") as mock_client:
+        mock_instance = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_instance
+        
+        workspaces = [Workspace.from_api_response(data) for data in workspace_list_response["data"]]
+        mock_instance.workspaces.list.return_value = (iter(workspaces), 2)
+        
+        result = runner.invoke(app, ["workspace", "list", "--organization", "test-org"])
+        return {"result": result, "workspaces": workspaces}
+
+@then("I should see workspace list")
+def check_workspace_list(list_all_workspaces):
+    result = list_all_workspaces["result"]
+    assert result.exit_code == 0
+    assert "my-app-dev" in result.stdout or "my-app-prod" in result.stdout
+```
+
+**Key practices:**
+- Scenarios describe *business outcomes*, not implementation details
+- Steps are outcome-focused: "I should see active run count" (not "emoji 🟢 is present")
+- Mock at `TFCClient` level, not httpx
+- Use `Mock(spec=...)` for type safety
+- Assertions check for presence/absence of information, not exact formatting
+
+**Use skill:** `adzic-index` to audit feature file quality against Specification by Example principles.
+
+### Unit Tests
+
+Unit tests verify isolated functions and models.
+
+**Pattern:**
+```python
+def test_run_status_is_successful():
+    """RunStatus.APPLIED should be considered successful."""
+    assert RunStatus.APPLIED.is_successful is True
+    assert RunStatus.PLANNED.is_successful is False
+
+def test_workspace_from_api_response_validates_id():
+    """Workspace.from_api_response should validate required ID field."""
+    with uv run pytest.raises(ValueError):
+        Workspace.from_api_response({"attributes": {}})  # Missing ID
+```
+
+**Key practices:**
+- One assertion per test (or closely related assertions)
+- Use fixtures for setup; prefer them to setUp methods
+- Mock external dependencies (API, filesystem); test logic, not I/O
+- Fast execution: unit tests should run in milliseconds
+
+**Use skill:** `farley-index` to audit test suite against properties: Fast, Honest, Necessary, Maintainable, Atomic, Repeatable.
+
+### Test Fixtures
+
+Reusable test data:
+
+```python
+@uv run pytest.fixture
+def workspace_detail_response():
+    """Mock TFC API response for workspace.show."""
+    return {
+        "data": {
+            "id": "ws-abc123",
+            "type": "workspaces",
+            "attributes": {
+                "name": "my-app-dev",
+                "terraform-version": "1.7.0",
+                "execution-mode": "remote",
+            },
+        }
+    }
+
+@uv run pytest.fixture
+def mock_client():
+    """Mock TFCClient for testing."""
+    return MagicMock(spec=TFCClient)
+```
+
+### Running Tests
+
+```bash
+# Run all tests with coverage
+uv run pytest
+
+# Run a specific test
+uv run pytest tests/test_cli/test_workspace_commands.py::test_list_workspaces
+
+# Run with focus (verbose output)
+uv run pytest -v -s tests/test_cli/test_workspace_commands.py
+
+# Run fast tests only (exclude UAT)
+uv run pytest -m "not uat"
+
+# Run with HTML coverage report
+uv run pytest --cov=terrapyne --cov-report=html
+```
+
+**Target:** 65% coverage minimum (enforced by pre-commit).
+
+## TDD Workflow
+
+Use the `test-accordion` skill to expand/contract test scope elastically:
+
+1. **Red**: Write a failing test (feature file or unit test)
+2. **Green**: Minimal code to make it pass
+3. **Refactor**: Improve clarity without changing behavior
+4. **Repeat**: Expand scope with next test
+
+Example workflow:
+```bash
+# Write test for workspace listing
+uv run pytest tests/test_cli/test_workspace_commands.py::test_list_workspaces -v
+
+# Code makes it pass
+uv run pytest tests/test_cli/test_workspace_commands.py -v
+
+# Add pagination test
+uv run pytest tests/test_cli/test_workspace_commands.py::test_list_workspaces_pagination -v
+
+# All pass
+uv run pytest tests/test_cli/test_workspace_commands.py -v
+```
+
+## Coverage
+
+- Minimum: 65% (enforced by `uv run pytest --cov-fail-under=65`)
+- Target: ≥75% for new features
+- Exception: Exclude vendored code, test fixtures, CLI shell layer
+
+Run locally before committing:
+```bash
+uv run pytest --cov=terrapyne --cov-report=term-missing
+```
+
+Check HTML report:
+```bash
+uv run pytest --cov=terrapyne --cov-report=html
+# open htmlcov/index.html
+```


### PR DESCRIPTION
## Summary

Add AGENTS.md at repo root as single entry point for agent guidance, with 
progressive disclosure to detailed guides under docs/guides/. All commands updated 
to use uv (project package manager).

## Contents

**AGENTS.md** (155 lines)
- Quick start with uv commands
- Core principles (Red/Green TDD, Adzic BDD, Atomic Commits, no AI markers)
- Development guides with links
- 6 essential Claude Code skills with when/how to use
- Project structure and testing patterns

**docs/guides/** (4 files, 829 lines)
- **python-and-testing.md** — Type hints, imports, naming, test structure, coverage
- **bdd-specifications.md** — Adzic Index (6 dimensions), feature files, step definitions
- **commits-and-review.md** — Atomic commits, conventional format, PR workflow
- **README.md** — Index with task-to-guide mapping

## Structure

Follows diataxis (progressive disclosure):
- AGENTS.md → detailed guides → architecture docs

Follows lean principles (JBGGE):
- 155-line root file
- Focused guides (no speculation)
- Links to existing documentation

## Standards

- No AI markers (per ~/.claude/CLAUDE.md)
- Skill-aware (references adzic-index, farley-index, commit, git, etc.)
- uv-native (all commands use uv run)

## Test Plan

- Read AGENTS.md — verify all links work
- Check docs/guides/ — skim for clarity
- Run commands from Quick Start section with uv
- Verify no pip or bare pytest references remain

## Depends On

#41 (test/workspace-dashboard-fixtures) should merge first.