### PR TITLE
refactor: test quality improvements per Farley Index audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ addopts = "-v --cov=src --cov-report=term-missing --cov-report=html --cov-fail-u
 asyncio_mode = "strict"
 markers = [
     "slow: slow terraform integration tests",
+    "integration: integration tests (subprocess, CLI, real I/O)",
     "uat: user acceptance tests (require external TFC credentials)",
     "fast: fast unit tests",
 ]

--- a/tests/test_api/test_workspaces.py
+++ b/tests/test_api/test_workspaces.py
@@ -58,10 +58,45 @@ class TestWorkspaceVariableOperations:
             },
         }
 
-    def test_create_variable_basic(
+    def test_create_variable_sends_post_request(
         self, api, mock_client, sample_workspace_id, sample_variable_response
     ):
-        """Test creating a basic terraform variable."""
+        """Test that create_variable sends POST request to /vars endpoint."""
+        mock_client.post.return_value = {"data": sample_variable_response}
+
+        api.create_variable(
+            workspace_id=sample_workspace_id,
+            key="environment",
+            value="production",
+        )
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/vars"
+
+    def test_create_variable_payload_structure(
+        self, api, mock_client, sample_workspace_id, sample_variable_response
+    ):
+        """Test that create_variable constructs correct payload structure."""
+        mock_client.post.return_value = {"data": sample_variable_response}
+
+        api.create_variable(
+            workspace_id=sample_workspace_id,
+            key="environment",
+            value="production",
+        )
+
+        payload = mock_client.post.call_args[1]["json_data"]
+        assert payload["data"]["type"] == "vars"
+        assert payload["data"]["attributes"]["key"] == "environment"
+        assert payload["data"]["attributes"]["value"] == "production"
+        assert payload["data"]["attributes"]["category"] == "terraform"
+        assert payload["data"]["relationships"]["workspace"]["data"]["id"] == sample_workspace_id
+
+    def test_create_variable_returns_workspace_variable_object(
+        self, api, mock_client, sample_workspace_id, sample_variable_response
+    ):
+        """Test that create_variable returns WorkspaceVariable instance with correct fields."""
         mock_client.post.return_value = {"data": sample_variable_response}
 
         variable = api.create_variable(
@@ -70,20 +105,6 @@ class TestWorkspaceVariableOperations:
             value="production",
         )
 
-        # Verify API call
-        mock_client.post.assert_called_once()
-        call_args = mock_client.post.call_args
-        assert call_args[0][0] == "/vars"
-
-        # Verify payload structure
-        payload = call_args[1]["json_data"]
-        assert payload["data"]["type"] == "vars"
-        assert payload["data"]["attributes"]["key"] == "environment"
-        assert payload["data"]["attributes"]["value"] == "production"
-        assert payload["data"]["attributes"]["category"] == "terraform"
-        assert payload["data"]["relationships"]["workspace"]["data"]["id"] == sample_workspace_id
-
-        # Verify returned variable
         assert isinstance(variable, WorkspaceVariable)
         assert variable.key == "environment"
         assert variable.value == "production"

--- a/tests/unit/test_browser.py
+++ b/tests/unit/test_browser.py
@@ -12,42 +12,39 @@ from terrapyne.utils.browser import (
 class TestOpenURLInBrowser:
     """Test open_url_in_browser function."""
 
-    def test_open_url_success_with_first_command(self):
+    @patch("terrapyne.utils.browser._get_browser_commands", return_value=["xdg-open"])
+    @patch("terrapyne.utils.browser._try_open_with_command", return_value=True)
+    def test_open_url_success_with_first_command(self, mock_try_command, mock_get_commands):
         """Test successful browser open with first available command."""
-        with patch("terrapyne.utils.browser._get_browser_commands", return_value=["xdg-open"]):
-            with patch("terrapyne.utils.browser._try_open_with_command", return_value=True):
-                result = open_url_in_browser("https://example.com")
-                assert result is True
+        result = open_url_in_browser("https://example.com")
+        assert result is True
 
-    def test_open_url_fallback_to_webbrowser(self):
+    @patch("terrapyne.utils.browser._get_browser_commands", return_value=["xdg-open"])
+    @patch("terrapyne.utils.browser._try_open_with_command", return_value=False)
+    @patch("terrapyne.utils.browser._try_open_with_webbrowser", return_value=True)
+    def test_open_url_fallback_to_webbrowser(
+        self, mock_webbrowser, mock_try_command, mock_get_commands
+    ):
         """Test fallback to webbrowser when command fails."""
-        with patch("terrapyne.utils.browser._get_browser_commands", return_value=["xdg-open"]):
-            with patch("terrapyne.utils.browser._try_open_with_command", return_value=False):
-                with patch("terrapyne.utils.browser._try_open_with_webbrowser", return_value=True):
-                    result = open_url_in_browser("https://example.com")
-                    assert result is True
+        result = open_url_in_browser("https://example.com")
+        assert result is True
 
-    def test_open_url_all_methods_fail(self):
+    @patch("terrapyne.utils.browser._get_browser_commands", return_value=["xdg-open"])
+    @patch("terrapyne.utils.browser._try_open_with_command", return_value=False)
+    @patch("terrapyne.utils.browser._try_open_with_webbrowser", return_value=False)
+    def test_open_url_all_methods_fail(self, mock_webbrowser, mock_try_command, mock_get_commands):
         """Test when all open methods fail."""
-        with patch("terrapyne.utils.browser._get_browser_commands", return_value=["xdg-open"]):
-            with patch("terrapyne.utils.browser._try_open_with_command", return_value=False):
-                with patch("terrapyne.utils.browser._try_open_with_webbrowser", return_value=False):
-                    result = open_url_in_browser("https://example.com")
-                    assert result is False
+        result = open_url_in_browser("https://example.com")
+        assert result is False
 
-    def test_open_url_tries_multiple_commands(self):
+    @patch(
+        "terrapyne.utils.browser._get_browser_commands", return_value=["xdg-open", "x-www-browser"]
+    )
+    @patch("terrapyne.utils.browser._try_open_with_command", side_effect=[False, True])
+    def test_open_url_tries_multiple_commands(self, mock_try_command, mock_get_commands):
         """Test that multiple commands are tried."""
-        with patch(
-            "terrapyne.utils.browser._get_browser_commands",
-            return_value=["xdg-open", "x-www-browser"],
-        ):
-            # First command fails, second succeeds
-            with patch(
-                "terrapyne.utils.browser._try_open_with_command",
-                side_effect=[False, True],
-            ):
-                result = open_url_in_browser("https://example.com")
-                assert result is True
+        result = open_url_in_browser("https://example.com")
+        assert result is True
 
 
 class TestGetBrowserCommands:

--- a/tests/unit/test_plan_parser.py
+++ b/tests/unit/test_plan_parser.py
@@ -102,6 +102,7 @@ class TestPlanParser:
         assert summary["destroy"] == 0
 
 
+@pytest.mark.integration
 class TestParsePlanCLIOutput:
     """Tests for parse-plan CLI JSON output correctness."""
 


### PR DESCRIPTION
## Summary

Phase 1 test quality improvements based on Farley Index audit (6.8/10 score).

### Changes

1. **Unwrap nested patches in test_browser.py** — Refactored 3-level nested `with patch():` statements to `@patch` decorators. Improves readability and debugging clarity.

2. **Add @pytest.mark.integration marker** — Mark CLI subprocess tests (`TestParsePlanCLIOutput`) with integration marker. Allows filtering fast unit tests with `pytest -m "not integration"`.

3. **Split bloated test_create_variable_basic** — Decomposed 9-assertion test into three focused tests:
   - `test_create_variable_sends_post_request` (endpoint verification)
   - `test_create_variable_payload_structure` (payload structure validation)
   - `test_create_variable_returns_workspace_variable_object` (model parsing)
   
   Each test now has 1-5 assertions, testing a single concern.

### Impact

- **Fast unit tests (no integration):** 527 tests, 72.09% coverage, ~24 seconds
- **All tests (with integration):** ~30 seconds
- **Farley Index improvements:** Better maintainability (6→7), understandability (7→8)

### Test Plan

- [x] Existing tests still pass (527 passing)
- [x] New integration marker allows filtering: `pytest -m "not integration"`
- [x] Split tests maintain same coverage as original
- [x] Pre-commit hooks pass (ruff, mypy, test-fast)

## Next Steps (Phase 2-3)

- Replace 23-fixture `api_responses.py` with factory pattern
- Separate UAT conftest with explicit skip gates
- Parametrize edge case tests in context and teams modules