### PR TITLE
docs(cli): improve organization error message with TFC_ORG hint

### DIFF
--- a/src/terrapyne/cli/utils.py
+++ b/src/terrapyne/cli/utils.py
@@ -49,8 +49,11 @@ def validate_context(
     org = resolve_organization(organization)
     if not org:
         raise ValueError(
-            "No organization specified and could not detect from context. "
-            "Specify: --organization ORGANIZATION or run in terraform directory."
+            "No organization specified and could not detect from context.\n"
+            "Specify one of:\n"
+            "  1. --organization ORGANIZATION flag\n"
+            "  2. TFC_ORG environment variable (e.g., export TFC_ORG=Takeda)\n"
+            "  3. Run in a terraform directory with .terraform/terraform.tfstate or terraform.tf"
         )
 
     ws = resolve_workspace(workspace)


### PR DESCRIPTION
## Summary

Improves the organization context resolution error message to clearly highlight all three ways to specify organization, with emphasis on the `TFC_ORG` environment variable as the most convenient persistent option.

## Changes

- Updated error message in `validate_context()` to list all three methods:
  1. `--organization` flag
  2. `TFC_ORG` environment variable (most user-friendly)
  3. Auto-detect from terraform directory

## Benefit

Users who get the "No organization specified" error now see the `TFC_ORG` option, which is the most convenient way to avoid repeating `--organization` on every command.

Example usage:
```bash
export TFC_ORG=Takeda
terrapyne workspace list  # No need for --organization flag anymore
```