### PR TITLE
feat(cli): implement log streaming for run follow (#13.4)

### DIFF
--- a/src/terrapyne/api/runs.py
+++ b/src/terrapyne/api/runs.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from terrapyne.core.exceptions import TFCAuthenticationError, TFCNotFoundError
 from terrapyne.models.apply import Apply
 from terrapyne.models.plan import Plan
 from terrapyne.models.run import Run
@@ -253,10 +254,14 @@ class RunsAPI:
             Plan log content as string
 
         Raises:
-            TFCAPIError: If logs not available
+            TFCAPIError: If logs not available (other than 404/403)
         """
         path = f"/plans/{plan_id}/logs"
-        return self.client._request("GET", path).text
+        try:
+            return self.client._request("GET", path).text
+        except (TFCNotFoundError, TFCAuthenticationError):
+            # Logs might not be ready yet
+            return ""
 
     def get_apply_logs(self, apply_id: str) -> str:
         """Get apply logs.
@@ -268,10 +273,14 @@ class RunsAPI:
             Apply log content as string
 
         Raises:
-            TFCAPIError: If logs not available
+            TFCAPIError: If logs not available (other than 404/403)
         """
         path = f"/applies/{apply_id}/logs"
-        return self.client._request("GET", path).text
+        try:
+            return self.client._request("GET", path).text
+        except (TFCNotFoundError, TFCAuthenticationError):
+            # Logs might not be ready yet
+            return ""
 
     def get_apply(self, apply_id: str) -> Apply:
         """Get apply details.

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -782,9 +782,15 @@ def _print_log_delta(full_log: str, last_pos: int) -> int:
     Returns:
         New position (length of full_log)
     """
+    if len(full_log) < last_pos:
+        # Logs were truncated or rotated; reset position
+        last_pos = 0
+
     new_content = full_log[last_pos:]
     if new_content:
-        print(new_content, end="", flush=True)
+        # Use rich console to automatically handle or strip ANSI escape codes
+        # depending on terminal capabilities
+        console.print(new_content, end="", markup=False)
     return len(full_log)
 
 
@@ -859,6 +865,14 @@ def run_follow(
                     last_apply_pos = _print_log_delta(apply_log, last_apply_pos)
                 except Exception:
                     pass  # Silently skip if logs not available yet
+
+            # Feedback if run fails before generating logs
+            if run.status.is_error and last_plan_pos == 0 and last_apply_pos == 0:
+                if current_stage != "error":
+                    current_stage = "error"
+                    console.print(
+                        f"\n[red]Run failed before generating logs: {run.status.value}[/red]"
+                    )
 
         try:
             final_run = client.runs.poll_until_complete(

--- a/tests/features/run_lifecycle.feature
+++ b/tests/features/run_lifecycle.feature
@@ -50,3 +50,10 @@ Feature: Infrastructure Change Lifecycle
     When I start monitoring the progress of "run-123"
     Then I should see continuous status updates
     And I should eventually see the final completion summary
+
+  Scenario: Stream logs progressively during monitoring
+    Given an infrastructure change "run-log-123" with plan and apply logs
+    When I follow the logs of "run-log-123"
+    Then the plan logs should be streamed progressively
+    And the apply logs should be streamed progressively
+    And no duplicate log lines should be printed

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -125,6 +125,11 @@ def test_watch_run():
     pass
 
 
+@scenario("../features/run_lifecycle.feature", "Stream logs progressively during monitoring")
+def test_stream_logs():
+    pass
+
+
 # ============================================================================
 # Scenarios - Diagnostics
 # ============================================================================
@@ -720,6 +725,85 @@ def start_monitoring(mock_client, run_id):
 def check_continuous_updates(cli_result):
     assert cli_result.exit_code == 0
     assert "applied" in cli_result.stdout.lower()
+
+
+@given(
+    parsers.parse('an infrastructure change "{run_id}" with plan and apply logs'),
+    target_fixture="mock_client",
+)
+def change_with_logs(run_id):
+    m = MagicMock()
+    # Initial status is planning
+    m.runs.get.return_value = Run.model_construct(
+        id=run_id, status=RunStatus.PLANNING, plan_id="plan-123", apply_id="apply-123"
+    )
+
+    # We will simulate polling logs. The first time we check plan logs it returns chunk 1, next time chunk 1+2
+    plan_log_chunks = ["Plan starting...", "Plan starting...\nPlan finished."]
+    apply_log_chunks = ["Apply starting...", "Apply starting...\nApply finished."]
+
+    m.runs.get_plan_logs.side_effect = plan_log_chunks
+    m.runs.get_apply_logs.side_effect = apply_log_chunks
+
+    # Mock the poll sequence
+    m.runs.poll_until_complete.return_value = Run.model_construct(
+        id=run_id, status=RunStatus.APPLIED, plan_id="plan-123", apply_id="apply-123"
+    )
+
+    return m
+
+
+@when(parsers.parse('I follow the logs of "{run_id}"'), target_fixture="cli_result")
+def follow_logs(mock_client, run_id):
+    with (
+        patch("terrapyne.cli.utils.validate_context") as v,
+        patch("terrapyne.cli.run_cmd.TFCClient") as c,
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+
+        # We need to simulate the stream_logs callback execution
+        def mock_poll(run_id, callback, max_wait):
+            # Simulate planning state
+            run_planning = Run.model_construct(
+                id=run_id, status=RunStatus.PLANNING, plan_id="plan-123"
+            )
+            callback(run_planning)
+            callback(run_planning)  # call again to get next chunk
+
+            # Simulate applying state
+            run_applying = Run.model_construct(
+                id=run_id, status=RunStatus.APPLYING, plan_id="plan-123", apply_id="apply-123"
+            )
+            callback(run_applying)
+            callback(run_applying)  # call again to get next chunk
+
+            return Run.model_construct(
+                id=run_id, status=RunStatus.APPLIED, plan_id="plan-123", apply_id="apply-123"
+            )
+
+        mock_client.runs.poll_until_complete.side_effect = mock_poll
+
+        return runner.invoke(app, ["run", "follow", run_id, "-o", "test-org"])
+
+
+@then("the plan logs should be streamed progressively")
+def check_plan_logs_streamed(cli_result):
+    assert "Plan starting..." in cli_result.stdout
+    assert "Plan finished." in cli_result.stdout
+
+
+@then("the apply logs should be streamed progressively")
+def check_apply_logs_streamed(cli_result):
+    assert "Apply starting..." in cli_result.stdout
+    assert "Apply finished." in cli_result.stdout
+
+
+@then("no duplicate log lines should be printed")
+def check_no_duplicate_logs(cli_result):
+    # Ensure "Plan starting..." and "Apply starting..." only appear once despite being returned in multiple chunks
+    assert cli_result.stdout.count("Plan starting...") == 1
+    assert cli_result.stdout.count("Apply starting...") == 1
 
 
 @given(


### PR DESCRIPTION
## Summary
- Enhances `_print_log_delta` with robust chunk/offset tracking and rich formatting to strip/handle ANSI escape codes correctly.
- Modifies SDK `runs.py` to elegantly handle 403/404 errors when logs are not yet available or generated.
- Provides immediate visual feedback if a run fails before log generation.
- Adds new BDD scenario verifying progressive stream logic without duplication.

## Test Plan
- [x] All 576 tests pass
- [ ] Manual: `terrapyne run follow <run-id>`