### PR TITLE
perf(cli): consolidate API calls in workspace show (#21)

### DIFF
--- a/src/terrapyne/api/workspaces.py
+++ b/src/terrapyne/api/workspaces.py
@@ -61,12 +61,18 @@ class WorkspaceAPI:
 
         return workspace_iterator(), total_count
 
-    def get(self, workspace_name: str, organization: str | None = None) -> Workspace:
+    def get(
+        self,
+        workspace_name: str,
+        organization: str | None = None,
+        include: str | None = "project",
+    ) -> Workspace:
         """Get workspace by name.
 
         Args:
             workspace_name: Workspace name
             organization: Organization name (uses client default if not specified)
+            include: Resources to include (default: project)
 
         Returns:
             Workspace instance
@@ -77,14 +83,19 @@ class WorkspaceAPI:
         org = self.client.get_organization(organization)
         path = f"/organizations/{org}/workspaces/{workspace_name}"
 
-        response = self.client.get(path, params={"include": "project"})
+        params = {}
+        if include:
+            params["include"] = include
+
+        response = self.client.get(path, params=params)
         return Workspace.from_api_response(response["data"], response.get("included", []))
 
-    def get_by_id(self, workspace_id: str) -> Workspace:
+    def get_by_id(self, workspace_id: str, include: str | None = "project") -> Workspace:
         """Get workspace by ID.
 
         Args:
             workspace_id: Workspace ID
+            include: Resources to include (default: project)
 
         Returns:
             Workspace instance
@@ -94,7 +105,11 @@ class WorkspaceAPI:
         """
         path = f"/workspaces/{workspace_id}"
 
-        response = self.client.get(path, params={"include": "project"})
+        params = {}
+        if include:
+            params["include"] = include
+
+        response = self.client.get(path, params=params)
         return Workspace.from_api_response(response["data"], response.get("included", []))
 
     def get_variables(self, workspace_id: str) -> list[WorkspaceVariable]:  # type: ignore[valid-type]

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -12,7 +12,6 @@ from terrapyne.api.client import TFCClient
 from terrapyne.api.vcs import VCSAPI
 from terrapyne.cli.utils import console, emit_json, handle_cli_errors, validate_context
 from terrapyne.core.exceptions import TFCAPIError
-from terrapyne.models.run import RunStatus
 from terrapyne.models.variable import WorkspaceVariable
 from terrapyne.utils.browser import get_workspace_url, open_url_in_browser
 from terrapyne.utils.rich_tables import (
@@ -133,28 +132,23 @@ def workspace_show(
         output_format = "json"
 
     with TFCClient(organization=org) as client:
-        ws = client.workspaces.get(cast(str, ws_name), org)
+        # Optimized: Fetch workspace, project, and latest run (with commit info) in ONE call (Task 21)
+        ws = client.workspaces.get(
+            cast(str, ws_name), org, include="project,latest-run,latest-run.configuration-version"
+        )
 
-        # 1. Fetch data for dashboard (Health & Activity)
-        latest_run = None
+        # 1. Fetch active run count (optimized: use a single count-only call)
+        latest_run = ws.latest_run
         active_runs_count = 0
         try:
-            # Fetch recent runs (optimized: get latest + check for active in one go)
-            # We fetch 20 to get a good snapshot of activity
-            runs, total_count = client.runs.list(ws.id, limit=20, include="configuration-version")
-            if runs:
-                latest_run = runs[0]
+            from terrapyne.models.run import RunStatus
 
-                # Count active runs in this window
-                active_list = RunStatus.get_active_statuses()
-                active_runs_count = sum(1 for r in runs if r.status in active_list)
+            active_list = RunStatus.get_active_statuses()
+            active_statuses = ",".join(active_list)
 
-                # If we have 20 runs and we might have more active ones outside this window,
-                # we could do a dedicated count call.
-                if len(runs) == 20 and total_count and total_count > 20:
-                    active_statuses = ",".join(active_list)
-                    _, count = client.runs.list(ws.id, status=active_statuses, limit=1)
-                    active_runs_count = count or 0
+            # Efficiently get total count of active runs
+            _, total_active = client.runs.list(ws.id, status=active_statuses, limit=1)
+            active_runs_count = total_active or 0
         except TFCAPIError as e:
             console.print(
                 f"\n[yellow]Warning:[/yellow] Unable to fetch run activity "

--- a/src/terrapyne/models/workspace.py
+++ b/src/terrapyne/models/workspace.py
@@ -95,7 +95,7 @@ class Workspace(BaseModel):
                     if item.get("type") == "runs" and item.get("id") == run_id:
                         from terrapyne.models.run import Run
 
-                        latest_run = Run.from_api_response(item)
+                        latest_run = Run.from_api_response(item, included=included)
                         break
 
         # Detect environment from workspace name

--- a/tests/unit/test_workspace_context.py
+++ b/tests/unit/test_workspace_context.py
@@ -25,6 +25,7 @@ class TestWorkspaceContextResolution:
         ws.created_at = None
         ws.updated_at = None
         ws.working_directory = "iac/dev"
+        ws.latest_run = None
         return ws
 
     @patch("terrapyne.cli.workspace_cmd.validate_context")
@@ -49,7 +50,11 @@ class TestWorkspaceContextResolution:
         result = runner.invoke(app, ["show"])  # no workspace arg
 
         # Must not crash and must have called .get() with the resolved name
-        mock_client.workspaces.get.assert_called_once_with(resolved_ws_name, "MyOrg")
+        mock_client.workspaces.get.assert_called_once_with(
+            resolved_ws_name,
+            "MyOrg",
+            include="project,latest-run,latest-run.configuration-version",
+        )
         assert result.exit_code == 0, f"exit={result.exit_code}\n{result.output}"
 
     @patch("terrapyne.cli.workspace_cmd.validate_context")


### PR DESCRIPTION
## Summary
- Implements `include` support in `WorkspaceAPI.get` and `get_by_id`.
- Merges project, latest-run, and commit data fetching into a single TFC API call.
- Optimizes active run counting using a lightweight filtered list request with `limit=1`.
- Fixes `Workspace` model to correctly propagate `included` resources to child models.

## Test Plan
- [x] All 576 tests pass.
- [ ] Manual: `terrapyne workspace show` should still show all dashboard data correctly but faster.