### PR TITLE
chore: ignore terrapyne.auto.tfvars.json artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,4 @@ terraform.rc
 
 # Git worktrees
 .worktrees/
+terrapyne.auto.tfvars.json


### PR DESCRIPTION
Small cleanup chore to ignore CLI artifacts.