### PR TITLE
fix(dev): move pytest-bdd into dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,4 +104,5 @@ exclude = ["src/terrapyne/logging.py", "src/terrapyne/terrapyne.py"]
 dev = [
     "import-linter>=2.11",
     "pytest>=9.0.3",
+    "pytest-bdd>=7.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1142,6 +1142,7 @@ dev = [
 dev = [
     { name = "import-linter" },
     { name = "pytest" },
+    { name = "pytest-bdd" },
 ]
 
 [package.metadata]
@@ -1176,6 +1177,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "import-linter", specifier = ">=2.11" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-bdd", specifier = ">=7.1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes X1 from the backlog.

`pytest-bdd` was listed under `[project.optional-dependencies] dev` but `uv sync` does not install optional extras by default. Every worktree created off `origin/main` was missing `pytest_bdd`, causing 16 `ModuleNotFoundError` collection errors across `tests/test_cli/`.

## Fix

Moved `pytest-bdd>=7.1.0` from optional extras into `[dependency-groups] dev` so it is always installed by `uv sync`.

## Test evidence

```
609 passed, 1 warning (tests/ --ignore=tests/uat)
```

Closes X1 in TODO.md