### PR TITLE
fix(arch): remove unittest.mock import from emit_json

### DIFF
--- a/src/terrapyne/cli/utils.py
+++ b/src/terrapyne/cli/utils.py
@@ -126,12 +126,8 @@ def emit_json(data):
     """Print data as JSON to stdout."""
     import json
     from datetime import datetime
-    from unittest.mock import Mock
 
     def _default(obj):
-        # Immediate guard for mock objects to prevent infinite recursion
-        if isinstance(obj, Mock):
-            return f"<Mock id={id(obj)}>"
         if isinstance(obj, datetime):
             return obj.isoformat()
         if hasattr(obj, "model_dump"):

--- a/tests/test_cli/test_json_output_bdd.py
+++ b/tests/test_cli/test_json_output_bdd.py
@@ -7,6 +7,7 @@ from pytest_bdd import given, parsers, scenario, then, when
 from typer.testing import CliRunner
 
 from terrapyne.cli.main import app
+from terrapyne.models.plan import Plan
 from terrapyne.models.project import Project
 from terrapyne.models.run import Run, RunStatus
 from terrapyne.models.team import Team
@@ -173,7 +174,13 @@ def run_named(run_id):
         workspace_id="ws-abc",
         plan_id="plan-1",
     )
-    m.runs.get_plan.return_value = MagicMock(additions=2, changes=1, destructions=0)
+    m.runs.get_plan.return_value = Plan.model_construct(
+        id="plan-1",
+        status="finished",
+        resource_additions=2,
+        resource_changes=1,
+        resource_destructions=0,
+    )
     m.workspaces.get_by_id.return_value = Workspace.model_construct(id="ws-abc", name="my-app-dev")
     return m
 

--- a/tests/unit/test_sdk_and_utils.py
+++ b/tests/unit/test_sdk_and_utils.py
@@ -97,6 +97,54 @@ class TestValidateContext:
             validate_context("my-org", require_workspace=True)
 
 
+class TestEmitJson:
+    """Tests for emit_json — must serialise real objects, no unittest.mock import."""
+
+    def test_no_unittest_mock_import_in_emit_json(self):
+        """emit_json must not import unittest.mock (test-framework leak into production code)."""
+        import ast
+        import inspect
+
+        from terrapyne.cli.utils import emit_json
+
+        source = inspect.getsource(emit_json)
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert "unittest" not in alias.name
+            if isinstance(node, ast.ImportFrom):
+                assert node.module is None or "unittest" not in node.module
+
+    def test_serialises_dict(self, capsys):
+        from terrapyne.cli.utils import emit_json
+
+        emit_json({"key": "value"})
+        out = capsys.readouterr().out
+        assert '"key": "value"' in out
+
+    def test_serialises_datetime(self, capsys):
+        from datetime import datetime
+
+        from terrapyne.cli.utils import emit_json
+
+        emit_json({"ts": datetime(2024, 1, 2, 3, 4, 5)})
+        out = capsys.readouterr().out
+        assert "2024-01-02" in out
+
+    def test_serialises_pydantic_model(self, capsys):
+        from pydantic import BaseModel
+
+        from terrapyne.cli.utils import emit_json
+
+        class Thing(BaseModel):
+            name: str
+
+        emit_json(Thing(name="hello"))
+        out = capsys.readouterr().out
+        assert '"hello"' in out
+
+
 class TestSDKNamespace:
     def test_sdk_imports(self):
         from terrapyne import RunsAPI, TFCClient


### PR DESCRIPTION
## Summary
- Removes `from unittest.mock import Mock` and the `isinstance(obj, Mock)` guard from `emit_json` in `src/terrapyne/cli/utils.py`
- Fixes the root cause: `test_json_output_bdd.py` was passing a `MagicMock` for the plan object; replaced with `Plan.model_construct(...)` so only real model objects reach the serialiser
- Adds `TestEmitJson` unit tests verifying no `unittest.mock` import exists in `emit_json`, and that dicts/datetimes/pydantic models all serialise correctly

## Test plan
- [ ] `uv run pytest tests/ --ignore=tests/uat -q --override-ini="addopts="` — 615 passed
- [ ] `grep -rn "unittest.mock" src/` — no output (success criteria met)