### PR TITLE
fix(cli): parse-plan no longer requires terraform binary

### DIFF
--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -770,8 +770,6 @@ def run_parse_plan(
         # Save to file
         terrapyne run parse-plan plan.txt --output parsed.json
     """
-    from terrapyne.core.local_binary import Terraform
-
     # Read plan from stdin or file
     if plan_file is None or str(plan_file) == "-":
         plan_text = sys.stdin.read()
@@ -783,8 +781,9 @@ def run_parse_plan(
             plan_text = f.read()
 
     # Parse it
-    tf = Terraform(".")
-    result = tf.parse_plain_text_plan(plan_text)
+    from terrapyne.core.plan_parser import TerraformPlainTextPlanParser
+
+    result = TerraformPlainTextPlanParser(plan_text).parse()
 
     # Format output
     if output_format == "json":

--- a/tests/unit/test_plan_parser.py
+++ b/tests/unit/test_plan_parser.py
@@ -4,8 +4,38 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from typer.testing import CliRunner
 
+from terrapyne.cli.main import app
 from terrapyne.core.plan_parser import TerraformPlainTextPlanParser
+
+runner = CliRunner()
+
+
+class TestParsePlanCLIDoesNotRequireTerraformBinary:
+    """parse-plan CLI command must not instantiate Terraform (no binary required)."""
+
+    SIMPLE_PLAN = """\
+Terraform will perform the following actions:
+
+  # aws_instance.web will be created
+  + resource "aws_instance" "web" {
+      + ami = "ami-12345678"
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+"""
+
+    def test_parse_plan_does_not_instantiate_terraform(self, tmp_path):
+        """parse-plan must not construct Terraform() — no binary needed."""
+        plan_file = tmp_path / "plan.txt"
+        plan_file.write_text(self.SIMPLE_PLAN)
+
+        with patch("terrapyne.core.local_binary.Terraform") as mock_tf_class:
+            result = runner.invoke(app, ["run", "parse-plan", str(plan_file)])
+
+        assert result.exit_code == 0, f"exit={result.exit_code}\n{result.output}"
+        mock_tf_class.assert_not_called()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- `tfc run parse-plan` previously instantiated `Terraform(".")` solely to call `parse_plain_text_plan()`, requiring the `terraform` binary to be in PATH
- Replace with `TerraformPlainTextPlanParser(text).parse()` directly — the parser is pure text processing
- Add a unit test asserting `Terraform` is never instantiated when invoking `parse-plan`

## Test plan
- [ ] `uv run pytest tests/unit/test_plan_parser.py::TestParsePlanCLIDoesNotRequireTerraformBinary` — new test verifies no `Terraform` instantiation
- [ ] Full suite: 612 tests pass