### PR TITLE
refactor(cli): move RunStatus import to module level in workspace_cmd

### DIFF
--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -13,6 +13,7 @@ from terrapyne.cli.utils import (
     validate_context,
 )
 from terrapyne.core.exceptions import TFCAPIError
+from terrapyne.models.run import RunStatus
 from terrapyne.models.variable import WorkspaceVariable
 from terrapyne.rendering.rich_tables import (
     render_workspace_dashboard,
@@ -121,8 +122,6 @@ def workspace_show(
         latest_run = ws.latest_run
         active_runs_count = 0
         try:
-            from terrapyne.models.run import RunStatus
-
             active_list = RunStatus.get_active_statuses()
             active_statuses = ",".join(active_list)
 

--- a/tests/unit/test_workspace_cmd_imports.py
+++ b/tests/unit/test_workspace_cmd_imports.py
@@ -1,0 +1,46 @@
+"""Test that workspace_cmd uses module-level imports (no function-body imports for non-circular cases)."""
+
+import ast
+import inspect
+
+
+def test_runstatus_is_module_level_import():
+    """RunStatus must be imported at module level in workspace_cmd, not inside a function body."""
+    from terrapyne.cli import workspace_cmd
+
+    source = inspect.getsource(workspace_cmd)
+    tree = ast.parse(source)
+
+    # Collect all import names at module level
+    module_level_imports = set()
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    module_level_imports.add(alias.asname or alias.name)
+            else:
+                for alias in node.names:
+                    module_level_imports.add(alias.asname or alias.name)
+
+    assert "RunStatus" in module_level_imports, (
+        "RunStatus must be imported at module level in workspace_cmd.py, not inside a function body"
+    )
+
+
+def test_no_runstatus_function_body_import():
+    """No function in workspace_cmd should import RunStatus inside its body."""
+    from terrapyne.cli import workspace_cmd
+
+    source = inspect.getsource(workspace_cmd)
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(node):
+                if isinstance(child, ast.ImportFrom):
+                    for alias in child.names:
+                        name = alias.asname or alias.name
+                        assert name != "RunStatus", (
+                            f"RunStatus imported inside function '{node.name}' — "
+                            "move it to module level"
+                        )


### PR DESCRIPTION
## Summary
- Moves `RunStatus` import from inside `workspace_show()` body to module level in `workspace_cmd.py`
- No circular dependency exists — inline import was unnecessary
- Adds regression test to prevent future function-body imports of `RunStatus` in `cli/workspace_cmd.py`

## Test plan
- [ ] `tests/unit/test_workspace_cmd_imports.py` — two new tests verify module-level import and absence of function-body import
- [ ] Full suite: 618 tests pass