### PR TITLE
fix(api): unify pagination, accumulate included across all pages

### DIFF
--- a/src/terrapyne/api/client.py
+++ b/src/terrapyne/api/client.py
@@ -36,6 +36,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger("terrapyne.api")
 
 
+class _PaginatedResult:
+    """Holds the result of a fully-consumed paginated API response."""
+
+    __slots__ = ("included", "items")
+
+    def __init__(self, items: list[dict[str, Any]], included: list[dict[str, Any]]) -> None:
+        self.items = items
+        self.included = included
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self.items)
+
+
 class TFCClient:
     """Terraform Cloud API client with retry logic and pagination support."""
 
@@ -302,31 +315,17 @@ class TFCClient:
         Yields:
             Individual resource dicts
         """
-        params = (params or {}).copy()
-        page = 1
-
-        while True:
-            params.update({"page[number]": page, "page[size]": min(page_size, 100)})
-            response_data = self.get(path, params=params)
-
-            # Yield items from current page
-            data = response_data.get("data", [])
-            if not data:
-                break
-
-            yield from data
-
-            # Check if there are more pages
-            links = response_data.get("links", {})
-            if not links.get("next"):
-                break
-
-            page += 1
+        result, _ = self.paginate_with_meta(path, params=params, page_size=page_size)
+        yield from result
 
     def paginate_with_meta(
         self, path: str, params: dict[str, Any] | None = None, page_size: int = 100
-    ) -> tuple[Any, int | None]:
+    ) -> "tuple[_PaginatedResult, int | None]":
         """Paginate through API results with metadata.
+
+        Collects all pages eagerly, accumulating ``included`` across every page
+        so that relationship data (e.g. project names) is available for every
+        item, not just those on the last page.
 
         Args:
             path: API path
@@ -334,55 +333,33 @@ class TFCClient:
             page_size: Items per page (max 100)
 
         Returns:
-            Tuple of (iterator-like object with .included property, total count)
+            Tuple of (_PaginatedResult with .items and .included, total count)
         """
-        params = (params or {}).copy()
-        params.update({"page[number]": 1, "page[size]": min(page_size, 100)})
+        base_params = (params or {}).copy()
+        base_params["page[size]"] = min(page_size, 100)
 
-        # Get first page to extract total count
-        first_response = self.get(path, params=params)
+        items: list[dict[str, Any]] = []
+        included: list[dict[str, Any]] = []
+        total_count: int | None = None
+        page = 1
 
-        # Extract total count from meta
-        total_count = None
-        meta = first_response.get("meta", {})
-        pagination = meta.get("pagination", {})
-        total_count = pagination.get("total-count")
+        while True:
+            base_params["page[number]"] = page
+            response_data = self.get(path, params=base_params)
 
-        # Generator to yield items from all pages
-        class ResponseIterator:
-            def __init__(self, first_resp: dict[str, Any], client: TFCClient, base_params: dict):
-                self.first_resp = first_resp
-                self.client = client
-                self.params = base_params
-                self.included = first_resp.get("included", [])
+            if total_count is None:
+                meta = response_data.get("meta", {})
+                total_count = meta.get("pagination", {}).get("total-count")
 
-            def __iter__(self) -> Iterator[dict[str, Any]]:
-                # Yield items from first page
-                data = self.first_resp.get("data", [])
-                yield from data
+            items.extend(response_data.get("data", []))
+            included.extend(response_data.get("included", []))
 
-                # Continue with remaining pages if there are any
-                links = self.first_resp.get("links", {})
-                if links.get("next"):
-                    page = 2
-                    while True:
-                        self.params["page[number]"] = page
-                        response_data = self.client.get(path, params=self.params)
-                        self.included = response_data.get("included", [])
+            if not response_data.get("links", {}).get("next"):
+                break
 
-                        data = response_data.get("data", [])
-                        if not data:
-                            break
+            page += 1
 
-                        yield from data
-
-                        links = response_data.get("links", {})
-                        if not links.get("next"):
-                            break
-
-                        page += 1
-
-        return ResponseIterator(first_response, self, params), total_count
+        return _PaginatedResult(items, included), total_count
 
     def get_organization(self, org: str | None = None) -> str:
         """Get organization name (from param, instance, or raise error).

--- a/tests/test_api/test_client.py
+++ b/tests/test_api/test_client.py
@@ -179,6 +179,107 @@ class TestAPIResponseHandling:
         assert len(results_list) > 0
 
 
+class TestPaginateWithMetaIncludedAccumulation:
+    """B3: paginate_with_meta must accumulate included across all pages."""
+
+    @patch("terrapyne.api.client.TFCClient.get")
+    def test_included_accumulates_across_pages(self, mock_get):
+        """included from all pages is available, not just the last page."""
+        creds = TerraformCredentials(host="app.terraform.io", token="test-token")
+        client = TFCClient(credentials=creds)
+
+        page1_url = "https://app.terraform.io/api/v2/workspaces?page%5Bnumber%5D=2"
+        mock_get.side_effect = [
+            {
+                "data": [{"id": "ws-1"}],
+                "included": [{"type": "projects", "id": "prj-1", "attributes": {"name": "Alpha"}}],
+                "meta": {"pagination": {"total-count": 2}},
+                "links": {"next": page1_url},
+            },
+            {
+                "data": [{"id": "ws-2"}],
+                "included": [{"type": "projects", "id": "prj-2", "attributes": {"name": "Beta"}}],
+                "meta": {"pagination": {"total-count": 2}},
+                "links": {},
+            },
+        ]
+
+        iterator, total = client.paginate_with_meta("/workspaces")
+        items = list(iterator)
+
+        assert total == 2
+        assert len(items) == 2
+        # Both project entries must be in included — not just the last page's
+        project_ids = {r["id"] for r in iterator.included if r["type"] == "projects"}
+        assert "prj-1" in project_ids, "prj-1 from page 1 was lost"
+        assert "prj-2" in project_ids, "prj-2 from page 2 missing"
+
+    @patch("terrapyne.api.client.TFCClient.get")
+    def test_included_is_empty_list_when_none_returned(self, mock_get):
+        """included defaults to empty list when API returns no included."""
+        creds = TerraformCredentials(host="app.terraform.io", token="test-token")
+        client = TFCClient(credentials=creds)
+
+        mock_get.return_value = {
+            "data": [{"id": "ws-1"}],
+            "meta": {"pagination": {"total-count": 1}},
+            "links": {},
+        }
+
+        iterator, _ = client.paginate_with_meta("/workspaces")
+        list(iterator)
+
+        assert iterator.included == []
+
+
+class TestPaginationUnification:
+    """A13: paginate_with_meta replaced with single pagination primitive."""
+
+    @patch("terrapyne.api.client.TFCClient.get")
+    def test_paginate_yields_items_without_meta(self, mock_get):
+        """paginate() still yields raw items for callers that don't need meta."""
+        creds = TerraformCredentials(host="app.terraform.io", token="test-token")
+        client = TFCClient(credentials=creds)
+
+        mock_get.return_value = {
+            "data": [{"id": "item-1"}, {"id": "item-2"}],
+            "meta": {"pagination": {"total-count": 2}},
+            "links": {},
+        }
+
+        items = list(client.paginate("/workspaces"))
+        assert [i["id"] for i in items] == ["item-1", "item-2"]
+
+    @patch("terrapyne.api.client.TFCClient.get")
+    def test_paginate_with_meta_returns_tuple(self, mock_get):
+        """paginate_with_meta returns (iterator, total_count) compatible tuple."""
+        creds = TerraformCredentials(host="app.terraform.io", token="test-token")
+        client = TFCClient(credentials=creds)
+
+        mock_get.return_value = {
+            "data": [{"id": "ws-1"}],
+            "included": [{"type": "projects", "id": "prj-1"}],
+            "meta": {"pagination": {"total-count": 42}},
+            "links": {},
+        }
+
+        result, total = client.paginate_with_meta("/workspaces")
+        assert total == 42
+        assert list(result) == [{"id": "ws-1"}]
+
+    @patch("terrapyne.api.client.TFCClient.get")
+    def test_no_inner_class_in_paginate_with_meta(self, mock_get):
+        """paginate_with_meta does not use a mutable ResponseIterator inner class."""
+        import inspect
+
+        import terrapyne.api.client as client_module
+
+        source = inspect.getsource(client_module.TFCClient.paginate_with_meta)
+        assert "class ResponseIterator" not in source, (
+            "ResponseIterator inner class should be removed"
+        )
+
+
 class TestHandleResponseError:
     """Test _handle_response_error maps HTTP status codes to domain exceptions."""
 


### PR DESCRIPTION
## Summary

- **B3**: `ResponseIterator` inner class overwrote `self.included` on each page fetch — workspace project-name resolution silently failed for workspaces on page 2+. Now all pages are collected eagerly so `included` is fully accumulated before iteration.
- **A13**: Eliminated the mutable `ResponseIterator` inner class; replaced with `_PaginatedResult` dataclass. `paginate()` now delegates to `paginate_with_meta()` — single pagination primitive, divergence eliminated.

## Test plan

- [ ] `TestPaginateWithMetaIncludedAccumulation::test_included_accumulates_across_pages` — verifies `prj-1` (page 1) and `prj-2` (page 2) are both in `.included`
- [ ] `TestPaginateWithMetaIncludedAccumulation::test_included_is_empty_list_when_none_returned` — edge case: no included in response
- [ ] `TestPaginationUnification::test_no_inner_class_in_paginate_with_meta` — asserts `ResponseIterator` source is gone
- [ ] Full suite: 625 passed