### PR TITLE
fix(projects): fnmatch post-filter for wildcard project find

### DIFF
--- a/src/terrapyne/api/projects.py
+++ b/src/terrapyne/api/projects.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import Iterator
+from fnmatch import fnmatch
 from typing import TYPE_CHECKING
 
 from terrapyne.api.client import TFCClient
@@ -52,7 +53,10 @@ class ProjectAPI:
 
         def project_iterator() -> Iterator[Project]:
             for item in items_iterator:
-                yield Project.from_api_response(item)
+                project = Project.from_api_response(item)
+                if search and "*" in search and not fnmatch(project.name, search):
+                    continue
+                yield project
 
         return project_iterator(), total_count
 

--- a/tests/test_api/test_projects.py
+++ b/tests/test_api/test_projects.py
@@ -146,6 +146,50 @@ def test_list_team_access(project_api, mock_client):
         mock_team_get.assert_called_once_with("team-1")
 
 
+@pytest.mark.parametrize(
+    "pattern, api_results, expected_names",
+    [
+        # prefix: 10234-* should match 10234-foo but not my-10234-project
+        (
+            "10234-*",
+            ["10234-foo", "my-10234-project", "10234-bar"],
+            ["10234-foo", "10234-bar"],
+        ),
+        # suffix: *-MAN should match PROJ-MAN but not PROJ-MANAGER
+        (
+            "*-MAN",
+            ["PROJ-MAN", "PROJ-MANAGER", "93126-MAN"],
+            ["PROJ-MAN", "93126-MAN"],
+        ),
+        # contains: *235* should match anything with 235 in name
+        (
+            "*235*",
+            ["10235-foo", "bar-235-baz", "99999-no"],
+            ["10235-foo", "bar-235-baz"],
+        ),
+    ],
+)
+def test_list_projects_wildcard_postfilter(
+    project_api, mock_client, pattern, api_results, expected_names
+):
+    """API results are post-filtered by fnmatch so false positives are excluded."""
+    mock_client.get_organization.return_value = "test-org"
+    mock_client.paginate_with_meta.return_value = (
+        iter(
+            [
+                {"id": f"prj-{i}", "type": "projects", "attributes": {"name": name}}
+                for i, name in enumerate(api_results)
+            ]
+        ),
+        len(api_results),
+    )
+
+    projects_iter, _ = project_api.list(search=pattern)
+    names = [p.name for p in projects_iter]
+
+    assert names == expected_names
+
+
 def test_list_team_access_enrichment_failure(project_api, mock_client):
     """Test team access listing when team name enrichment fails."""
     access_data = [


### PR DESCRIPTION
## Summary

- `project find 10234-*` was returning false positives (e.g. `my-10234-project`) because the wildcard was stripped to a bare substring for the API `q=` param with no subsequent filtering
- After fetching API results, apply Python `fnmatch` on the original pattern to exclude non-matching names
- Covers prefix (`10234-*`), suffix (`*-MAN`), and contains (`*235*`) patterns
- Exact-name searches (no `*`) are unaffected

## Test plan

- [ ] 3 new parametrized test cases in `tests/test_api/test_projects.py::test_list_projects_wildcard_postfilter` — prefix, suffix, contains
- [ ] All 623 tests pass