### PR TITLE
fix(state-versions): use filter[workspace][id] directly, remove round-trip

### DIFF
--- a/src/terrapyne/api/state_versions.py
+++ b/src/terrapyne/api/state_versions.py
@@ -36,15 +36,9 @@ class StateVersionsAPI:
         path = "/state-versions"
         params: dict[str, Any] = {}
 
-        # TFC API requires org+name, not workspace ID
-        if not (organization and workspace_name) and workspace_id:
-            from terrapyne.api.workspaces import WorkspaceAPI
-
-            ws = WorkspaceAPI(self.client).get_by_id(workspace_id)
-            workspace_name = ws.name
-            organization = self.client.get_organization()
-
-        if organization and workspace_name:
+        if workspace_id:
+            params["filter[workspace][id]"] = workspace_id
+        elif organization and workspace_name:
             params["filter[organization][name]"] = organization
             params["filter[workspace][name]"] = workspace_name
         else:

--- a/tests/test_api/test_state_versions.py
+++ b/tests/test_api/test_state_versions.py
@@ -45,6 +45,25 @@ def test_list_state_versions(api, mock_client):
     mock_client.paginate_with_meta.assert_called_once()
 
 
+def test_list_state_versions_by_workspace_id_no_round_trip(api, mock_client):
+    """When workspace_id is given, use filter[workspace][id] directly — no workspace lookup."""
+    mock_client.paginate_with_meta.return_value = (
+        [{"id": "sv-1", "attributes": {"serial": 1, "status": "complete", "resource-count": 5}}],
+        1,
+    )
+
+    versions, _total = api.list(workspace_id="ws-xyz")
+
+    assert len(versions) == 1
+    assert versions[0].id == "sv-1"
+    # Must use filter[workspace][id] directly
+    call_kwargs = mock_client.paginate_with_meta.call_args
+    params = call_kwargs[1].get("params") or call_kwargs[0][1]
+    assert params.get("filter[workspace][id]") == "ws-xyz"
+    # Must NOT have triggered a workspace lookup
+    mock_client.get.assert_not_called()
+
+
 def test_get_state_version(api, mock_client):
     """Test getting a single state version by ID."""
     mock_client.get.return_value = {


### PR DESCRIPTION
## Summary

- `StateVersionsAPI.list(workspace_id=...)` previously resolved the workspace ID to a name+org via `WorkspaceAPI.get_by_id()`, then used `filter[workspace][name]`
- TFC's `/state-versions` endpoint accepts `filter[workspace][id]` directly, so no round-trip is needed
- When `workspace_id` is provided, now uses `filter[workspace][id]` directly; name/org path remains for explicit `organization+workspace_name` calls

## Test plan

- [x] New test `test_list_state_versions_by_workspace_id_no_round_trip` asserts `filter[workspace][id]` param is used and `client.get` is never called (no workspace lookup)
- [x] All 630 existing tests pass