### PR TITLE
fix(models): RunStatus.get_active_statuses() returns list[RunStatus] not list[str]

### DIFF
--- a/src/terrapyne/api/runs.py
+++ b/src/terrapyne/api/runs.py
@@ -67,7 +67,7 @@ class RunsAPI:
         """Get all currently active (non-terminal) runs for a workspace."""
         from terrapyne.models.run import RunStatus
 
-        active_statuses = ",".join(RunStatus.get_active_statuses())
+        active_statuses = ",".join(s.value for s in RunStatus.get_active_statuses())
         # TFC API supports comma-separated status filter
         runs, _ = self.list(workspace_id, status=active_statuses, limit=100)
         return runs

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -123,7 +123,7 @@ def workspace_show(
         active_runs_count = 0
         try:
             active_list = RunStatus.get_active_statuses()
-            active_statuses = ",".join(active_list)
+            active_statuses = ",".join(s.value for s in active_list)
 
             # Efficiently get total count of active runs
             _, total_active = client.runs.list(ws.id, status=active_statuses, limit=1)

--- a/src/terrapyne/models/run.py
+++ b/src/terrapyne/models/run.py
@@ -60,7 +60,7 @@ class RunStatus(StrEnum):
     DISCARDED = "discarded"  # Terminal state
 
     @staticmethod
-    def get_active_statuses() -> builtins.list[str]:
+    def get_active_statuses() -> builtins.list["RunStatus"]:
         """Get list of active (non-terminal) statuses."""
         return [
             RunStatus.PENDING,

--- a/tests/test_api/test_runs.py
+++ b/tests/test_api/test_runs.py
@@ -377,6 +377,28 @@ class TestRunRetrieval:
         assert runs[0].status == RunStatus.APPLIED
 
 
+class TestRunStatusActiveStatuses:
+    """Tests for RunStatus.get_active_statuses() return type."""
+
+    def test_get_active_statuses_returns_list_of_run_status(self):
+        """get_active_statuses() must return list[RunStatus], not list[str]."""
+        statuses = RunStatus.get_active_statuses()
+        assert len(statuses) > 0
+        assert all(isinstance(s, RunStatus) for s in statuses)
+
+    def test_get_active_statuses_excludes_terminal_states(self):
+        """Terminal states must not appear in active statuses."""
+        statuses = RunStatus.get_active_statuses()
+        terminal = {
+            RunStatus.APPLIED,
+            RunStatus.ERRORED,
+            RunStatus.CANCELED,
+            RunStatus.FORCE_CANCELED,
+            RunStatus.DISCARDED,
+        }
+        assert not terminal.intersection(statuses)
+
+
 class TestRunIntegration:
     """Test full run lifecycle workflows."""
 


### PR DESCRIPTION
## Summary

- Correct `get_active_statuses()` return type annotation from `list[str]` to `list[RunStatus]`
- Update `RunsAPI.get_active_runs()` and `workspace_cmd` to encode `.value` explicitly at the call site when building the comma-separated API query param

## Test plan

- [ ] `TestRunStatusActiveStatuses::test_get_active_statuses_returns_list_of_run_status` — asserts all returned elements are `RunStatus` instances
- [ ] `TestRunStatusActiveStatuses::test_get_active_statuses_excludes_terminal_states` — asserts terminal states absent
- [ ] Full suite: 631 tests passed