### PR TITLE
feat(cli): promote workspace health to real subcommand

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -16,6 +16,7 @@ Workspace management and inspection.
 
 - `list`: List workspaces in an organization.
 - `show`: Show detailed workspace information.
+- `health`: Show workspace health snapshot (status, active runs, latest commit).
 - `vcs`: Show VCS configuration for a workspace.
 - `variables`: List variables in a workspace.
 - `var-set`: Create or update workspace variables (supports bulk setting).

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -214,6 +214,48 @@ def workspace_show(
         render_workspace_vcs(ws)
 
 
+@app.command("health")
+@handle_cli_errors
+def workspace_health(
+    ctx: typer.Context,
+    workspace: str | None = typer.Argument(
+        None, help="Workspace name (auto-detected from terraform.tf if in terraform directory)"
+    ),
+    organization: str | None = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="TFC organization (auto-detected from context if available)",
+    ),
+):
+    """Show workspace health snapshot (status, active runs, latest commit)."""
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(
+            cast(str, ws_name), org, include="latest-run,latest-run.configuration-version"
+        )
+
+        latest_run = ws.latest_run
+        active_runs_count = 0
+        try:
+            active_list = RunStatus.get_active_statuses()
+            active_statuses = ",".join(active_list)
+            _, total_active = client.runs.list(ws.id, status=active_statuses, limit=1)
+            active_runs_count = total_active or 0
+        except TFCAPIError as e:
+            console.print(
+                f"\n[yellow]Warning:[/yellow] Unable to fetch run activity "
+                f"(API error {e.status_code})"
+            )
+
+        from terrapyne.rendering.rich_tables import render_workspace_snapshot
+
+        render_workspace_snapshot(
+            workspace=ws, latest_run=latest_run, active_runs_count=active_runs_count
+        )
+
+
 @app.command("vcs")
 @handle_cli_errors
 def workspace_vcs(

--- a/src/terrapyne/rendering/rich_tables.py
+++ b/src/terrapyne/rendering/rich_tables.py
@@ -94,6 +94,48 @@ def render_workspace_dashboard(
     console.print(snap_table)
 
 
+def render_workspace_snapshot(
+    workspace: Workspace, latest_run: Run | None = None, active_runs_count: int = 0
+) -> None:
+    """Render health & activity snapshot panel only (no detail table or variables).
+
+    Args:
+        workspace: Workspace instance
+        latest_run: Most recent run instance
+        active_runs_count: Number of queued or in-progress runs
+    """
+    snap_table = Table(
+        title=f"Health & Activity Snapshot — {workspace.name}", show_header=False, box=None
+    )
+    snap_table.add_column("Property", style="bold cyan", width=25)
+    snap_table.add_column("Value")
+
+    health_status = "Unknown (no runs found)"
+    if latest_run:
+        from terrapyne.rendering.logging import format_relative_time
+
+        status = latest_run.status
+        time_ago = (
+            format_relative_time(latest_run.created_at) if latest_run.created_at else "unknown time"
+        )
+        if status.is_successful:
+            health_status = f"🟢 Healthy (last run {status.value} {time_ago})"
+        elif status.is_error:
+            health_status = f"🔴 Unhealthy (last run {status.value} {time_ago})"
+        else:
+            health_status = f"🟡 Warning (last run {status.value} {time_ago})"
+
+    snap_table.add_row("Health", health_status)
+    snap_table.add_row("Active Runs", str(active_runs_count) if active_runs_count > 0 else "None")
+
+    if latest_run and latest_run.commit_sha:
+        author = latest_run.commit_author or "Unknown"
+        snap_table.add_row("Latest Commit", f"{latest_run.commit_sha[:7]} ({author})")
+        snap_table.add_row("Commit Message", latest_run.commit_message or "N/A")
+
+    console.print(snap_table)
+
+
 def render_workspace_variables(variables: Sequence[WorkspaceVariable]) -> None:
     """Render workspace variables as a Rich table.
 

--- a/tests/features/workspace_dashboard.feature
+++ b/tests/features/workspace_dashboard.feature
@@ -36,3 +36,11 @@ Feature: Workspace Activity Dashboard
     Then I should receive JSON output
     And I should see snapshot section with latest run info
     And I should see active runs count in the snapshot
+
+  Scenario: health subcommand renders snapshot-only view
+    Given a workspace with a recently applied run
+    When I run the health subcommand
+    Then I should see the workspace health snapshot
+    And I should see the active run count
+    And I should not see workspace variables section
+    And I should not see VCS configuration section

--- a/tests/test_cli/test_workspace_dashboard_bdd.py
+++ b/tests/test_cli/test_workspace_dashboard_bdd.py
@@ -55,6 +55,14 @@ def test_dashboard_json_output():
     """Scenario: JSON output includes workspace snapshot data."""
 
 
+@scenario(
+    "../features/workspace_dashboard.feature",
+    "health subcommand renders snapshot-only view",
+)
+def test_health_subcommand_snapshot_only():
+    """Scenario: health subcommand renders snapshot-only view."""
+
+
 # ============================================================================
 # Background / Given Steps
 # ============================================================================
@@ -202,10 +210,21 @@ def show_workspace_json(workspace_detail_response, run_list_response):
 # ============================================================================
 
 
+def _get_command_result(request):
+    """Return command result dict from whichever 'when' fixture is active."""
+    for fixture_name in ("show_workspace_dashboard", "run_health_subcommand"):
+        try:
+            return request.getfixturevalue(fixture_name)
+        except pytest.FixtureLookupError:
+            pass
+    raise pytest.FixtureLookupError("", request, "No command result fixture found")
+
+
 @then("I should see the workspace health snapshot")
-def check_health_snapshot(show_workspace_dashboard):
+def check_health_snapshot(request):
     """Verify health snapshot section is rendered."""
-    result = show_workspace_dashboard["result"]
+    ctx = _get_command_result(request)
+    result = ctx["result"]
     assert result.exit_code == 0, f"Command failed: {result.stdout}"
     # Outcome: health status is visible (not checking for specific emoji)
     output_lower = result.stdout.lower()
@@ -230,9 +249,10 @@ def check_latest_run_info(show_workspace_dashboard):
 
 
 @then("I should see the active run count")
-def check_active_run_count(show_workspace_dashboard):
+def check_active_run_count(request):
     """Verify active run count is displayed."""
-    result = show_workspace_dashboard["result"]
+    ctx = _get_command_result(request)
+    result = ctx["result"]
     assert result.exit_code == 0
     # Outcome: run count information is present
     output_lower = result.stdout.lower()
@@ -372,3 +392,51 @@ def check_json_active_count(show_workspace_json):
     assert any(keyword in str(data).lower() for keyword in ["active", "count", "runs"]), (
         "Active runs count not in JSON"
     )
+
+
+@pytest.fixture
+@when("I run the health subcommand")
+def run_health_subcommand(workspace_detail_response, run_list_response):
+    """Execute workspace health command and capture output."""
+    with patch("terrapyne.api.client.TFCClient") as mock_client:
+        mock_instance = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_instance
+
+        workspace = Workspace.from_api_response(workspace_detail_response["data"])
+        runs = [Run.from_api_response(data) for data in run_list_response["data"]]
+
+        mock_instance.workspaces.get.return_value = workspace
+        mock_instance.runs.list.return_value = (runs, len(runs))
+
+        result = runner.invoke(
+            app,
+            [
+                "workspace",
+                "health",
+                "my-app-dev",
+                "--organization",
+                "test-org",
+            ],
+        )
+
+        return {
+            "result": result,
+            "workspace": workspace,
+            "runs": runs,
+        }
+
+
+@then("I should not see workspace variables section")
+def check_no_variables_section(run_health_subcommand):
+    """Verify variables section is absent from health output."""
+    result = run_health_subcommand["result"]
+    assert result.exit_code == 0, f"Command failed: {result.stdout}"
+    assert "Variables" not in result.stdout, "Variables section should not appear in health output"
+
+
+@then("I should not see VCS configuration section")
+def check_no_vcs_section(run_health_subcommand):
+    """Verify VCS configuration section is absent from health output."""
+    result = run_health_subcommand["result"]
+    assert result.exit_code == 0
+    assert "VCS" not in result.stdout, "VCS section should not appear in health output"

--- a/tests/test_docs/test_cli_reference.py
+++ b/tests/test_docs/test_cli_reference.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def test_cli_reference_no_phantom_health_command():
-    """workspace health does not exist in the CLI; must not be documented."""
+def test_cli_reference_documents_health_command():
+    """workspace health exists in the CLI and must be documented."""
     content = Path("docs/reference/cli-reference.md").read_text()
-    assert "- `health`" not in content
+    assert "- `health`" in content


### PR DESCRIPTION
## Summary

- Adds `tfc workspace health <name>` subcommand that renders a focused Health & Activity Snapshot panel (status, active run count, latest commit SHA/author/message)
- Extracts `render_workspace_snapshot` from `rich_tables.py` to support snapshot-only rendering without variables or VCS sections
- BDD scenario added to `workspace_dashboard.feature`; all 635 tests pass
- CLI reference updated; the phantom-health guard test inverted to assert the command is now documented

## Test plan

- [x] New BDD scenario: `health subcommand renders snapshot-only view` — passes
- [x] Existing 5 workspace dashboard BDD scenarios — still pass
- [x] `test_cli_reference_documents_health_command` — asserts `health` is in CLI reference
- [x] Full suite: 635 passed