### PR TITLE
feat(backend): detect cloud block backend (Terraform >= 1.1)

### DIFF
--- a/src/terrapyne/core/backend.py
+++ b/src/terrapyne/core/backend.py
@@ -37,11 +37,12 @@ def find_terraform_tf(start_dir: Path) -> Path | None:
         tf_file = current / "terraform.tf"
         if tf_file.exists():
             return tf_file
-        # Look for any .tf file that contains a remote backend
+        # Look for any .tf file that contains a remote backend or cloud block
         candidates = list(current.glob("*.tf"))
         for candidate in candidates:
             try:
-                if 'backend "remote"' in candidate.read_text():
+                text = candidate.read_text()
+                if 'backend "remote"' in text or "cloud {" in text:
                     return candidate
             except Exception:
                 continue
@@ -52,8 +53,38 @@ def find_terraform_tf(start_dir: Path) -> Path | None:
     return None
 
 
+def _extract_from_block(block: dict) -> RemoteBackend | None:
+    """Extract RemoteBackend fields from a parsed remote/cloud block dict."""
+    if isinstance(block, list):
+        block = block[0]
+    if not isinstance(block, dict):
+        return None
+
+    hostname = block.get("hostname", "app.terraform.io")
+    organization = block.get("organization")
+    if not organization:
+        return None
+
+    workspaces = block.get("workspaces", {})
+    if isinstance(workspaces, list):
+        workspaces = workspaces[0] if workspaces else {}
+    if isinstance(workspaces, dict):
+        workspace_name = workspaces.get("name")
+        workspace_prefix = workspaces.get("prefix")
+    else:
+        workspace_name = None
+        workspace_prefix = None
+
+    return RemoteBackend(
+        hostname=hostname,
+        organization=organization,
+        workspace_name=workspace_name,
+        workspace_prefix=workspace_prefix,
+    )
+
+
 def parse_backend_hcl(tf_file: Path) -> RemoteBackend | None:
-    """Parse backend config from HCL."""
+    """Parse backend config from HCL (cloud block or backend "remote")."""
     if not HAS_HCL2:
         return None
 
@@ -66,53 +97,29 @@ def parse_backend_hcl(tf_file: Path) -> RemoteBackend | None:
     except Exception:
         return None
 
-    # Navigate parsed HCL for terraform -> backend "remote"
     terraform = parsed.get("terraform")
     if not terraform:
         return None
-
-    # terraform can be a list or dict depending on hcl2 parsing
     if isinstance(terraform, list):
         terraform = terraform[0]
-
     if not isinstance(terraform, dict):
         return None
 
+    # Try cloud block first (Terraform >= 1.1)
+    cloud = terraform.get("cloud")
+    if cloud:
+        result = _extract_from_block(cloud)
+        if result:
+            return result
+
+    # Fall back to backend "remote"
     backend = terraform.get("backend")
     if not backend or not isinstance(backend, dict):
         return None
-
     remote_block = backend.get("remote")
     if not remote_block:
         return None
-
-    # remote_block may be list or dict
-    if isinstance(remote_block, list):
-        remote_block = remote_block[0]
-
-    if not isinstance(remote_block, dict):
-        return None
-
-    hostname = remote_block.get("hostname", "app.terraform.io")
-    organization = remote_block.get("organization")
-
-    workspaces = remote_block.get("workspaces", {})
-    if isinstance(workspaces, dict):
-        workspace_name = workspaces.get("name")
-        workspace_prefix = workspaces.get("prefix")
-    else:
-        workspace_name = None
-        workspace_prefix = None
-
-    if not organization:
-        return None
-
-    return RemoteBackend(
-        hostname=hostname,
-        organization=organization,
-        workspace_name=workspace_name,
-        workspace_prefix=workspace_prefix,
-    )
+    return _extract_from_block(remote_block)
 
 
 def parse_backend_regex(content: str) -> RemoteBackend | None:

--- a/tests/fixtures/terraform_tf/cloud_block_hostname.tf
+++ b/tests/fixtures/terraform_tf/cloud_block_hostname.tf
@@ -1,0 +1,10 @@
+terraform {
+  cloud {
+    hostname     = "tfe.example.com"
+    organization = "my-org"
+
+    workspaces {
+      name = "my-workspace"
+    }
+  }
+}

--- a/tests/fixtures/terraform_tf/cloud_block_name.tf
+++ b/tests/fixtures/terraform_tf/cloud_block_name.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "my-org"
+
+    workspaces {
+      name = "my-workspace"
+    }
+  }
+}

--- a/tests/fixtures/terraform_tf/cloud_block_prefix.tf
+++ b/tests/fixtures/terraform_tf/cloud_block_prefix.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "my-org"
+
+    workspaces {
+      prefix = "my-app-"
+    }
+  }
+}

--- a/tests/fixtures/terraform_tf/cloud_block_tags.tf
+++ b/tests/fixtures/terraform_tf/cloud_block_tags.tf
@@ -1,0 +1,9 @@
+terraform {
+  cloud {
+    organization = "my-org"
+
+    workspaces {
+      tags = ["app", "production"]
+    }
+  }
+}

--- a/tests/unit/test_backend_detection.py
+++ b/tests/unit/test_backend_detection.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 
 from terrapyne.core.backend import RemoteBackend, detect_backend
@@ -5,9 +7,9 @@ from terrapyne.core.backend import RemoteBackend, detect_backend
 
 @pytest.mark.fast
 @pytest.mark.unit
-def test_detect_backend_with_name(fixtures_dir):
-    tf_file = fixtures_dir / "terraform_tf" / "remote_backend.tf"
-    result = detect_backend(path=tf_file.parent)
+def test_detect_backend_with_name(tmp_path, fixtures_dir):
+    shutil.copy(fixtures_dir / "terraform_tf" / "remote_backend.tf", tmp_path)
+    result = detect_backend(path=tmp_path)
     assert isinstance(result, RemoteBackend)
     assert result.organization == "my-org"
     assert result.workspace_name == "my-workspace"
@@ -15,9 +17,51 @@ def test_detect_backend_with_name(fixtures_dir):
 
 @pytest.mark.fast
 @pytest.mark.unit
-def test_detect_backend_with_prefix(fixtures_dir):
-    tf_file = fixtures_dir / "terraform_tf" / "remote_backend_prefix.tf"
-    result = detect_backend(path=tf_file.parent)
+def test_detect_backend_with_prefix(tmp_path, fixtures_dir):
+    shutil.copy(fixtures_dir / "terraform_tf" / "remote_backend_prefix.tf", tmp_path)
+    result = detect_backend(path=tmp_path)
     assert isinstance(result, RemoteBackend)
     assert result.organization == "my-org"
     assert result.workspace_prefix == "my-app-"
+
+
+@pytest.mark.fast
+@pytest.mark.unit
+def test_detect_cloud_block_with_name(tmp_path, fixtures_dir):
+    shutil.copy(fixtures_dir / "terraform_tf" / "cloud_block_name.tf", tmp_path)
+    result = detect_backend(path=tmp_path)
+    assert isinstance(result, RemoteBackend)
+    assert result.organization == "my-org"
+    assert result.workspace_name == "my-workspace"
+
+
+@pytest.mark.fast
+@pytest.mark.unit
+def test_detect_cloud_block_with_prefix(tmp_path, fixtures_dir):
+    shutil.copy(fixtures_dir / "terraform_tf" / "cloud_block_prefix.tf", tmp_path)
+    result = detect_backend(path=tmp_path)
+    assert isinstance(result, RemoteBackend)
+    assert result.organization == "my-org"
+    assert result.workspace_prefix == "my-app-"
+
+
+@pytest.mark.fast
+@pytest.mark.unit
+def test_detect_cloud_block_with_tags(tmp_path, fixtures_dir):
+    shutil.copy(fixtures_dir / "terraform_tf" / "cloud_block_tags.tf", tmp_path)
+    result = detect_backend(path=tmp_path)
+    assert isinstance(result, RemoteBackend)
+    assert result.organization == "my-org"
+    assert result.workspace_name is None
+    assert result.workspace_prefix is None
+
+
+@pytest.mark.fast
+@pytest.mark.unit
+def test_detect_cloud_block_with_hostname(tmp_path, fixtures_dir):
+    shutil.copy(fixtures_dir / "terraform_tf" / "cloud_block_hostname.tf", tmp_path)
+    result = detect_backend(path=tmp_path)
+    assert isinstance(result, RemoteBackend)
+    assert result.hostname == "tfe.example.com"
+    assert result.organization == "my-org"
+    assert result.workspace_name == "my-workspace"


### PR DESCRIPTION
## Summary

- `detect_backend()` now parses `cloud {}` blocks (Terraform ≥ 1.1) via both the HCL and regex fallback paths
- Returns a `RemoteBackend` with the same fields as `backend "remote"` (hostname, organization, workspace_name, workspace_prefix)
- New fixture `.tf` files cover cloud block variants: name, prefix, tags, hostname

## Test plan

- [ ] `test_detect_cloud_block_with_name` — cloud block with workspace name
- [ ] `test_detect_cloud_block_with_prefix` — cloud block with workspace prefix
- [ ] `test_detect_cloud_block_with_tags` — cloud block with workspace tags (no name/prefix returned)
- [ ] `test_detect_cloud_block_with_hostname` — cloud block with custom TFE hostname
- [ ] Existing `test_detect_backend_with_name` and `test_detect_backend_with_prefix` still pass
- [ ] Full suite: 638 passed