### PR TITLE
refactor(namespace): move Terraform to terrapyne.local (#a9)

### DIFF
--- a/src/terrapyne/__init__.py
+++ b/src/terrapyne/__init__.py
@@ -34,7 +34,6 @@ from .core.exceptions import (
     WorkspaceAlreadyExistsError,
     WorkspaceNotFoundError,
 )
-from .core.local_binary import Terraform
 from .core.plan_parser import TerraformPlainTextPlanParser as PlanParser
 from .models.plan import Plan
 from .models.project import Project
@@ -44,6 +43,28 @@ from .models.team_access import TeamProjectAccess
 from .models.variable import WorkspaceVariable
 from .models.vcs import VCSConnection
 from .models.workspace import Workspace, WorkspaceVCS
+
+_DEPRECATED = {
+    "Terraform": ("terrapyne.local.Terraform", "terrapyne.local"),
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED:
+        import warnings
+
+        _canonical, module = _DEPRECATED[name]
+        warnings.warn(
+            f"terrapyne.{name} is deprecated; use `from {module} import {name}` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        import importlib
+
+        mod = importlib.import_module(".local", package=__name__)
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "VCSAPI",
@@ -65,7 +86,6 @@ __all__ = [
     "Team",
     "TeamProjectAccess",
     "TeamsAPI",
-    "Terraform",
     "TerraformApplyError",
     "TerraformCredentials",
     "TerraformError",

--- a/src/terrapyne/local/__init__.py
+++ b/src/terrapyne/local/__init__.py
@@ -1,0 +1,12 @@
+"""terrapyne.local — local Terraform binary wrapper.
+
+Use this sub-namespace for operations against a locally installed terraform CLI:
+
+    from terrapyne.local import Terraform
+
+    tf = Terraform(workspace_directory="/path/to/workspace")
+"""
+
+from terrapyne.core.local_binary import Terraform
+
+__all__ = ["Terraform"]

--- a/tests/unit/test_local_namespace.py
+++ b/tests/unit/test_local_namespace.py
@@ -1,0 +1,51 @@
+"""Tests for A9: Terraform accessible via terrapyne.local sub-namespace.
+
+Success criteria:
+- `terrapyne.local.Terraform` resolves to the class
+- `from terrapyne import Terraform` still works but emits DeprecationWarning
+- `Terraform` is NOT in `terrapyne.__all__`
+"""
+
+import warnings
+
+
+class TestLocalNamespace:
+    def test_terraform_accessible_via_local_submodule(self):
+        import terrapyne.local
+
+        assert hasattr(terrapyne.local, "Terraform")
+
+    def test_terraform_class_importable_from_local(self):
+        from terrapyne.local import Terraform
+
+        assert Terraform is not None
+
+    def test_terraform_not_in_top_level_all(self):
+        import terrapyne
+
+        assert "Terraform" not in terrapyne.__all__
+
+    def test_top_level_terraform_import_emits_deprecation_warning(self):
+        # Force re-evaluation of the deprecated attribute each time
+        import terrapyne
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cls = terrapyne.Terraform  # noqa: F841
+        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecation_warnings, (
+            "Expected a DeprecationWarning when accessing terrapyne.Terraform"
+        )
+        assert (
+            "terrapyne.local" in str(deprecation_warnings[0].message).lower()
+            or "deprecated" in str(deprecation_warnings[0].message).lower()
+        )
+
+    def test_top_level_terraform_still_returns_correct_class(self):
+        import terrapyne
+        from terrapyne.local import Terraform
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cls = terrapyne.Terraform
+        assert cls is Terraform


### PR DESCRIPTION
## Summary

- `Terraform` (local subprocess wrapper) is now exported from `terrapyne.local` — `from terrapyne.local import Terraform`
- Removed `Terraform` from `terrapyne.__all__`, keeping the top-level namespace focused on the TFC HTTP SDK
- `from terrapyne import Terraform` still works via module `__getattr__` but emits a `DeprecationWarning` pointing users to the new path

## Test plan

- [ ] `from terrapyne.local import Terraform` resolves correctly
- [ ] `terrapyne.Terraform` access emits `DeprecationWarning` with message referencing `terrapyne.local`
- [ ] `"Terraform"` is absent from `terrapyne.__all__`
- [ ] Full test suite passes (656 non-integration tests)