### PR TITLE
feat(varsets): Variable Sets — list, show, apply, remove

### DIFF
--- a/src/terrapyne/api/client.py
+++ b/src/terrapyne/api/client.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from terrapyne.api.runs import RunsAPI
     from terrapyne.api.state_versions import StateVersionsAPI
     from terrapyne.api.teams import TeamsAPI
+    from terrapyne.api.varsets import VarSetAPI
     from terrapyne.api.vcs import VCSAPI
     from terrapyne.api.workspaces import WorkspaceAPI
 
@@ -132,6 +133,13 @@ class TFCClient:
         from terrapyne.api.vcs import VCSAPI
 
         return VCSAPI(self)
+
+    @cached_property
+    def varsets(self) -> "VarSetAPI":
+        """Get variable sets API instance."""
+        from terrapyne.api.varsets import VarSetAPI
+
+        return VarSetAPI(self)
 
     def _log_request(self, method: str, url: str, params: Any = None) -> float:
         if self.debug:

--- a/src/terrapyne/api/varsets.py
+++ b/src/terrapyne/api/varsets.py
@@ -1,0 +1,93 @@
+"""Variable Sets API methods."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from terrapyne.api.client import TFCClient
+from terrapyne.models.varset import VariableSet, VariableSetVariable
+
+
+class VarSetAPI:
+    """Variable Sets API operations."""
+
+    def __init__(self, client: TFCClient):
+        self.client = client
+
+    def list(self, organization: str | None = None) -> tuple[Iterator[VariableSet], int | None]:
+        """List variable sets in an organization.
+
+        Args:
+            organization: Organization name (uses client default if not specified)
+
+        Returns:
+            Tuple of (iterator of VariableSet instances, total count or None)
+        """
+        org = self.client.get_organization(organization)
+        path = f"/organizations/{org}/varsets"
+        items_iterator, total_count = self.client.paginate_with_meta(path)
+
+        def varset_iterator() -> Iterator[VariableSet]:
+            for item in items_iterator:
+                yield VariableSet.from_api_response(item)
+
+        return varset_iterator(), total_count
+
+    def get_by_name(self, name: str, organization: str | None = None) -> VariableSet:
+        """Get a variable set by name.
+
+        Args:
+            name: Variable set name
+            organization: Organization name (uses client default if not specified)
+
+        Returns:
+            VariableSet instance
+
+        Raises:
+            ValueError: If variable set not found
+        """
+        varsets, _ = self.list(organization)
+        for vs in varsets:
+            if vs.name == name:
+                return vs
+        raise ValueError(f"Variable set '{name}' not found in organization.")
+
+    def get_variables(self, varset_id: str) -> Iterator[VariableSetVariable]:
+        """List variables in a variable set.
+
+        Args:
+            varset_id: Variable set ID
+
+        Yields:
+            VariableSetVariable instances
+        """
+        path = f"/varsets/{varset_id}/relationships/vars"
+        items_iterator, _ = self.client.paginate_with_meta(path)
+        for item in items_iterator:
+            yield VariableSetVariable.from_api_response(item)
+
+    def apply(self, varset_id: str, workspace_id: str) -> None:
+        """Apply a variable set to a workspace.
+
+        Args:
+            varset_id: Variable set ID
+            workspace_id: Workspace ID to apply to
+        """
+        path = f"/varsets/{varset_id}/relationships/workspaces"
+        self.client.post(
+            path,
+            json_data={"data": [{"type": "workspaces", "id": workspace_id}]},
+        )
+
+    def remove(self, varset_id: str, workspace_id: str) -> None:
+        """Remove a variable set from a workspace.
+
+        Args:
+            varset_id: Variable set ID
+            workspace_id: Workspace ID to remove from
+        """
+        path = f"/varsets/{varset_id}/relationships/workspaces"
+        self.client.delete(
+            path,
+            json_data={"data": [{"type": "workspaces", "id": workspace_id}]},
+        )

--- a/src/terrapyne/cli/main.py
+++ b/src/terrapyne/cli/main.py
@@ -13,6 +13,7 @@ from terrapyne.cli import (
     run_cmd,
     state_cmd,
     team_cmd,
+    varset_cmd,
     vcs_cmd,
     workspace_cmd,
 )
@@ -45,6 +46,9 @@ app.add_typer(project_cmd.app, name="project")
 
 # Add state commands
 app.add_typer(state_cmd.app, name="state")
+
+# Add varset commands
+app.add_typer(varset_cmd.app, name="varset")
 
 
 def version_callback(value: bool) -> None:

--- a/src/terrapyne/cli/varset_cmd.py
+++ b/src/terrapyne/cli/varset_cmd.py
@@ -1,0 +1,152 @@
+"""Variable Set CLI commands."""
+
+import typer
+
+from terrapyne.cli.utils import (
+    console,
+    emit_json,
+    get_client,
+    handle_cli_errors,
+    resolve_organization,
+)
+
+app = typer.Typer(help="Variable set management commands")
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
+
+
+@app.command("list")
+@handle_cli_errors
+def varset_list(
+    ctx: typer.Context,
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """List variable sets in an organization."""
+    org = resolve_organization(organization)
+    if not org:
+        console.print("[red]Error: Organization not specified.[/red]")
+        raise typer.Exit(1)
+
+    with get_client(ctx, organization=org) as client:
+        varsets, total = client.varsets.list(org)
+        vs_list = list(varsets)
+
+        if json_output:
+            emit_json([vs.model_dump() for vs in vs_list])
+            return
+
+        from rich.table import Table
+
+        table = Table(title=f"Variable Sets in {org}", show_lines=False)
+        table.add_column("Name", style="bold")
+        table.add_column("Description")
+        table.add_column("Global", justify="center")
+        table.add_column("Vars", justify="right")
+        table.add_column("Workspaces", justify="right")
+
+        for vs in vs_list:
+            table.add_row(
+                vs.name,
+                vs.description or "",
+                "yes" if vs.global_ else "no",
+                str(vs.var_count),
+                str(vs.workspace_count),
+            )
+
+        console.print(table)
+        if total:
+            console.print(f"\n[dim]Total: {total}[/dim]")
+
+
+@app.command("show")
+@handle_cli_errors
+def varset_show(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Variable set name"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Show variables in a variable set."""
+    org = resolve_organization(organization)
+    if not org:
+        console.print("[red]Error: Organization not specified.[/red]")
+        raise typer.Exit(1)
+
+    with get_client(ctx, organization=org) as client:
+        vs = client.varsets.get_by_name(name, org)
+        variables = list(client.varsets.get_variables(vs.id))
+
+        if json_output:
+            emit_json({"varset": vs.model_dump(), "variables": [v.model_dump() for v in variables]})
+            return
+
+        from rich.table import Table
+
+        console.print(f"[bold]Variable Set:[/bold] {vs.name}")
+        if vs.description:
+            console.print(f"[dim]{vs.description}[/dim]")
+        console.print(f"[dim]Global: {'yes' if vs.global_ else 'no'}[/dim]")
+        console.print()
+
+        table = Table(title="Variables", show_lines=False)
+        table.add_column("Key", style="bold")
+        table.add_column("Value")
+        table.add_column("Category")
+        table.add_column("Sensitive", justify="center")
+
+        for var in variables:
+            table.add_row(
+                var.key,
+                var.display_value,
+                var.category,
+                "yes" if var.sensitive else "no",
+            )
+
+        console.print(table)
+
+
+@app.command("apply")
+@handle_cli_errors
+def varset_apply(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Variable set name"),
+    workspace: str = typer.Option(..., "--workspace", "-w", help="Workspace name"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+):
+    """Apply a variable set to a workspace."""
+    org = resolve_organization(organization)
+    if not org:
+        console.print("[red]Error: Organization not specified.[/red]")
+        raise typer.Exit(1)
+
+    with get_client(ctx, organization=org) as client:
+        vs = client.varsets.get_by_name(name, org)
+        ws = client.workspaces.get(workspace, org)
+        client.varsets.apply(vs.id, ws.id)
+        console.print(f"[green]Applied variable set '{name}' to workspace '{workspace}'.[/green]")
+
+
+@app.command("remove")
+@handle_cli_errors
+def varset_remove(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Variable set name"),
+    workspace: str = typer.Option(..., "--workspace", "-w", help="Workspace name"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+):
+    """Remove a variable set from a workspace."""
+    org = resolve_organization(organization)
+    if not org:
+        console.print("[red]Error: Organization not specified.[/red]")
+        raise typer.Exit(1)
+
+    with get_client(ctx, organization=org) as client:
+        vs = client.varsets.get_by_name(name, org)
+        ws = client.workspaces.get(workspace, org)
+        client.varsets.remove(vs.id, ws.id)
+        console.print(f"[green]Removed variable set '{name}' from workspace '{workspace}'.[/green]")

--- a/src/terrapyne/models/varset.py
+++ b/src/terrapyne/models/varset.py
@@ -1,0 +1,73 @@
+"""Variable Set models for org/project-scoped shared variables."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VariableSetVariable(BaseModel):
+    """A variable belonging to a variable set."""
+
+    id: str
+    key: str
+    value: str | None = None
+    description: str | None = None
+    category: str  # "terraform" or "env"
+    hcl: bool = False
+    sensitive: bool = False
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any]) -> "VariableSetVariable":
+        attrs = data.get("attributes", {})
+        return cls.model_construct(
+            id=data["id"],
+            key=attrs.get("key", ""),
+            value=attrs.get("value"),
+            description=attrs.get("description"),
+            category=attrs.get("category", "terraform"),
+            hcl=attrs.get("hcl", False),
+            sensitive=attrs.get("sensitive", False),
+        )
+
+    @property
+    def display_value(self) -> str:
+        if self.sensitive:
+            return "••••••••"
+        return self.value or ""
+
+    @property
+    def is_terraform_var(self) -> bool:
+        return self.category == "terraform"
+
+    @property
+    def is_env_var(self) -> bool:
+        return self.category == "env"
+
+
+class VariableSet(BaseModel):
+    """Terraform Cloud variable set (org or project scoped)."""
+
+    id: str
+    name: str
+    description: str | None = None
+    global_: bool = Field(False, alias="global")
+    var_count: int = 0
+    workspace_count: int = 0
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any]) -> "VariableSet":
+        attrs = data.get("attributes", {})
+        return cls(
+            id=data["id"],
+            **{
+                "global": attrs.get("global", False),
+            },
+            name=attrs.get("name", ""),
+            description=attrs.get("description"),
+            var_count=attrs.get("var-count", 0),
+            workspace_count=attrs.get("workspace-count", 0),
+        )

--- a/tests/test_api/test_varsets.py
+++ b/tests/test_api/test_varsets.py
@@ -1,0 +1,161 @@
+"""Tests for VarSetAPI methods."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from terrapyne.api.varsets import VarSetAPI
+from terrapyne.models.varset import VariableSet, VariableSetVariable
+
+
+def _varset_item(id="varset-xyz789", name="shared-aws-creds", global_=False):
+    return {
+        "id": id,
+        "type": "varsets",
+        "attributes": {
+            "name": name,
+            "description": "Shared AWS credentials",
+            "global": global_,
+            "var-count": 2,
+            "workspace-count": 3,
+        },
+    }
+
+
+def _var_item(id="var-abc123", key="AWS_REGION", value="eu-west-1"):
+    return {
+        "id": id,
+        "type": "vars",
+        "attributes": {
+            "key": key,
+            "value": value,
+            "description": None,
+            "category": "env",
+            "hcl": False,
+            "sensitive": False,
+        },
+    }
+
+
+class TestVarSetAPIList:
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get_organization.return_value = "my-org"
+        return client
+
+    @pytest.fixture
+    def api(self, mock_client):
+        return VarSetAPI(mock_client)
+
+    def test_list_calls_correct_path(self, api, mock_client):
+        mock_client.paginate_with_meta.return_value = (
+            MagicMock(items=[_varset_item()], included=[]),
+            1,
+        )
+        _varsets, _count = api.list()
+        mock_client.paginate_with_meta.assert_called_once()
+        path = mock_client.paginate_with_meta.call_args[0][0]
+        assert "/organizations/my-org/varsets" in path
+
+    def test_list_returns_varset_instances(self, api, mock_client):
+        item = _varset_item()
+        result = MagicMock()
+        result.__iter__ = MagicMock(return_value=iter([item]))
+        result.included = []
+        mock_client.paginate_with_meta.return_value = (result, 1)
+        varsets, _count = api.list()
+        vs_list = list(varsets)
+        assert len(vs_list) == 1
+        assert isinstance(vs_list[0], VariableSet)
+        assert vs_list[0].name == "shared-aws-creds"
+
+    def test_list_returns_total_count(self, api, mock_client):
+        result = MagicMock()
+        result.__iter__ = MagicMock(return_value=iter([]))
+        result.included = []
+        mock_client.paginate_with_meta.return_value = (result, 42)
+        _, count = api.list()
+        assert count == 42
+
+
+class TestVarSetAPIGet:
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get_organization.return_value = "my-org"
+        return client
+
+    @pytest.fixture
+    def api(self, mock_client):
+        return VarSetAPI(mock_client)
+
+    def test_get_by_name_returns_matching_varset(self, api, mock_client):
+        item = _varset_item(name="shared-aws-creds")
+        result = MagicMock()
+        result.__iter__ = MagicMock(return_value=iter([item]))
+        result.included = []
+        mock_client.paginate_with_meta.return_value = (result, 1)
+        vs = api.get_by_name("shared-aws-creds")
+        assert vs.name == "shared-aws-creds"
+
+    def test_get_by_name_raises_when_not_found(self, api, mock_client):
+        result = MagicMock()
+        result.__iter__ = MagicMock(return_value=iter([]))
+        result.included = []
+        mock_client.paginate_with_meta.return_value = (result, 0)
+        with pytest.raises(ValueError, match="not found"):
+            api.get_by_name("nonexistent")
+
+    def test_get_variables_calls_correct_path(self, api, mock_client):
+        result = MagicMock()
+        result.__iter__ = MagicMock(return_value=iter([_var_item()]))
+        result.included = []
+        mock_client.paginate_with_meta.return_value = (result, 1)
+        list(api.get_variables("varset-xyz789"))
+        mock_client.paginate_with_meta.assert_called_once()
+        path = mock_client.paginate_with_meta.call_args[0][0]
+        assert "/varsets/varset-xyz789/relationships/vars" in path
+
+    def test_get_variables_returns_varsetvariable_instances(self, api, mock_client):
+        result = MagicMock()
+        result.__iter__ = MagicMock(return_value=iter([_var_item()]))
+        result.included = []
+        mock_client.paginate_with_meta.return_value = (result, 1)
+        variables = list(api.get_variables("varset-xyz789"))
+        assert len(variables) == 1
+        assert isinstance(variables[0], VariableSetVariable)
+        assert variables[0].key == "AWS_REGION"
+
+
+class TestVarSetAPIApplyRemove:
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        return client
+
+    @pytest.fixture
+    def api(self, mock_client):
+        return VarSetAPI(mock_client)
+
+    def test_apply_posts_to_correct_path(self, api, mock_client):
+        api.apply("varset-xyz789", "ws-abc123")
+        mock_client.post.assert_called_once()
+        path = mock_client.post.call_args[0][0]
+        assert "/varsets/varset-xyz789/relationships/workspaces" in path
+
+    def test_apply_sends_correct_payload(self, api, mock_client):
+        api.apply("varset-xyz789", "ws-abc123")
+        payload = mock_client.post.call_args[1]["json_data"]
+        assert payload == {"data": [{"type": "workspaces", "id": "ws-abc123"}]}
+
+    def test_remove_deletes_correct_path(self, api, mock_client):
+        api.remove("varset-xyz789", "ws-abc123")
+        mock_client.delete.assert_called_once()
+        path = mock_client.delete.call_args[0][0]
+        assert "/varsets/varset-xyz789/relationships/workspaces" in path
+
+    def test_remove_sends_correct_payload(self, api, mock_client):
+        api.remove("varset-xyz789", "ws-abc123")
+        payload = mock_client.delete.call_args[1]["json_data"]
+        assert payload == {"data": [{"type": "workspaces", "id": "ws-abc123"}]}

--- a/tests/test_cli/test_varset_commands.py
+++ b/tests/test_cli/test_varset_commands.py
@@ -1,0 +1,174 @@
+"""CLI tests for varset commands."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from terrapyne.cli.main import app
+from terrapyne.models.varset import VariableSet, VariableSetVariable
+
+runner = CliRunner()
+
+
+def _make_varset(id="varset-xyz789", name="shared-aws-creds", global_=False):
+    return VariableSet.model_construct(
+        id=id,
+        name=name,
+        description="Shared AWS credentials",
+        global_=global_,
+        var_count=2,
+        workspace_count=3,
+    )
+
+
+def _make_var(id="var-abc123", key="AWS_REGION", value="eu-west-1", sensitive=False):
+    return VariableSetVariable.model_construct(
+        id=id,
+        key=key,
+        value=value,
+        description=None,
+        category="env",
+        hcl=False,
+        sensitive=sensitive,
+    )
+
+
+class TestVarsetListCommand:
+    def _invoke(self, mock_client):
+        with (
+            patch("terrapyne.cli.utils.resolve_organization") as mock_org,
+            patch("terrapyne.api.client.TFCClient") as mock_tfc,
+        ):
+            mock_org.return_value = "test-org"
+            mock_tfc.return_value.__enter__.return_value = mock_client
+            return runner.invoke(app, ["varset", "list", "-o", "test-org"])
+
+    def test_list_exits_zero(self):
+        mock_client = MagicMock()
+        mock_client.varsets.list.return_value = ([_make_varset()], 1)
+        result = self._invoke(mock_client)
+        assert result.exit_code == 0
+
+    def test_list_shows_varset_name(self):
+        mock_client = MagicMock()
+        mock_client.varsets.list.return_value = ([_make_varset(name="shared-aws-creds")], 1)
+        result = self._invoke(mock_client)
+        assert "shared-aws-creds" in result.stdout
+
+    def test_list_json_output(self):
+        import json
+
+        mock_client = MagicMock()
+        mock_client.varsets.list.return_value = ([_make_varset()], 1)
+        with (
+            patch("terrapyne.cli.utils.resolve_organization") as mock_org,
+            patch("terrapyne.api.client.TFCClient") as mock_tfc,
+        ):
+            mock_org.return_value = "test-org"
+            mock_tfc.return_value.__enter__.return_value = mock_client
+            result = runner.invoke(app, ["varset", "list", "-o", "test-org", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert data[0]["name"] == "shared-aws-creds"
+
+
+class TestVarsetShowCommand:
+    def _invoke(self, mock_client, name="shared-aws-creds"):
+        with (
+            patch("terrapyne.cli.utils.resolve_organization") as mock_org,
+            patch("terrapyne.api.client.TFCClient") as mock_tfc,
+        ):
+            mock_org.return_value = "test-org"
+            mock_tfc.return_value.__enter__.return_value = mock_client
+            return runner.invoke(app, ["varset", "show", name, "-o", "test-org"])
+
+    def test_show_exits_zero(self):
+        mock_client = MagicMock()
+        mock_client.varsets.get_by_name.return_value = _make_varset()
+        mock_client.varsets.get_variables.return_value = iter([_make_var()])
+        result = self._invoke(mock_client)
+        assert result.exit_code == 0
+
+    def test_show_displays_variable_key(self):
+        mock_client = MagicMock()
+        mock_client.varsets.get_by_name.return_value = _make_varset()
+        mock_client.varsets.get_variables.return_value = iter([_make_var(key="AWS_REGION")])
+        result = self._invoke(mock_client)
+        assert "AWS_REGION" in result.stdout
+
+    def test_show_masks_sensitive_variables(self):
+        mock_client = MagicMock()
+        mock_client.varsets.get_by_name.return_value = _make_varset()
+        mock_client.varsets.get_variables.return_value = iter(
+            [_make_var(key="SECRET_KEY", value="s3cr3t", sensitive=True)]
+        )
+        result = self._invoke(mock_client)
+        assert "s3cr3t" not in result.stdout
+        assert "••••••••" in result.stdout
+
+    def test_show_not_found_exits_nonzero(self):
+        mock_client = MagicMock()
+        mock_client.varsets.get_by_name.side_effect = ValueError("not found")
+        result = self._invoke(mock_client, name="missing")
+        assert result.exit_code != 0
+
+
+class TestVarsetApplyCommand:
+    def _invoke(self, mock_client, varset="shared-aws-creds", workspace="my-ws"):
+        with (
+            patch("terrapyne.cli.utils.resolve_organization") as mock_org,
+            patch("terrapyne.api.client.TFCClient") as mock_tfc,
+        ):
+            mock_org.return_value = "test-org"
+            mock_tfc.return_value.__enter__.return_value = mock_client
+            return runner.invoke(
+                app, ["varset", "apply", varset, "--workspace", workspace, "-o", "test-org"]
+            )
+
+    def test_apply_exits_zero(self):
+        mock_client = MagicMock()
+        mock_client.varsets.get_by_name.return_value = _make_varset()
+        mock_client.workspaces.get.return_value = MagicMock(id="ws-abc123")
+        mock_client.varsets.apply.return_value = None
+        result = self._invoke(mock_client)
+        assert result.exit_code == 0
+
+    def test_apply_calls_api_with_ids(self):
+        mock_client = MagicMock()
+        vs = _make_varset(id="varset-xyz789")
+        ws = MagicMock(id="ws-abc123")
+        mock_client.varsets.get_by_name.return_value = vs
+        mock_client.workspaces.get.return_value = ws
+        self._invoke(mock_client)
+        mock_client.varsets.apply.assert_called_once_with("varset-xyz789", "ws-abc123")
+
+
+class TestVarsetRemoveCommand:
+    def _invoke(self, mock_client, varset="shared-aws-creds", workspace="my-ws"):
+        with (
+            patch("terrapyne.cli.utils.resolve_organization") as mock_org,
+            patch("terrapyne.api.client.TFCClient") as mock_tfc,
+        ):
+            mock_org.return_value = "test-org"
+            mock_tfc.return_value.__enter__.return_value = mock_client
+            return runner.invoke(
+                app, ["varset", "remove", varset, "--workspace", workspace, "-o", "test-org"]
+            )
+
+    def test_remove_exits_zero(self):
+        mock_client = MagicMock()
+        mock_client.varsets.get_by_name.return_value = _make_varset()
+        mock_client.workspaces.get.return_value = MagicMock(id="ws-abc123")
+        mock_client.varsets.remove.return_value = None
+        result = self._invoke(mock_client)
+        assert result.exit_code == 0
+
+    def test_remove_calls_api_with_ids(self):
+        mock_client = MagicMock()
+        vs = _make_varset(id="varset-xyz789")
+        ws = MagicMock(id="ws-abc123")
+        mock_client.varsets.get_by_name.return_value = vs
+        mock_client.workspaces.get.return_value = ws
+        self._invoke(mock_client)
+        mock_client.varsets.remove.assert_called_once_with("varset-xyz789", "ws-abc123")

--- a/tests/test_models/test_varset_models.py
+++ b/tests/test_models/test_varset_models.py
@@ -1,0 +1,100 @@
+"""Tests for VariableSet and VariableSetVariable models."""
+
+from terrapyne.models.varset import VariableSet, VariableSetVariable
+
+
+class TestVariableSetVariable:
+    """Tests for VariableSetVariable model."""
+
+    def _make_var_response(self, **overrides):
+        data = {
+            "id": "var-abc123",
+            "type": "vars",
+            "attributes": {
+                "key": "AWS_REGION",
+                "value": "eu-west-1",
+                "description": "AWS region",
+                "category": "env",
+                "hcl": False,
+                "sensitive": False,
+            },
+        }
+        data["attributes"].update(overrides)
+        return data
+
+    def test_from_api_response_populates_fields(self):
+        var = VariableSetVariable.from_api_response(self._make_var_response())
+        assert var.id == "var-abc123"
+        assert var.key == "AWS_REGION"
+        assert var.value == "eu-west-1"
+        assert var.category == "env"
+        assert var.hcl is False
+        assert var.sensitive is False
+
+    def test_sensitive_variable_masks_display_value(self):
+        var = VariableSetVariable.from_api_response(
+            self._make_var_response(sensitive=True, value="secret")
+        )
+        assert var.display_value == "••••••••"
+
+    def test_non_sensitive_variable_shows_value(self):
+        var = VariableSetVariable.from_api_response(self._make_var_response())
+        assert var.display_value == "eu-west-1"
+
+    def test_null_value_shows_empty_string(self):
+        var = VariableSetVariable.from_api_response(self._make_var_response(value=None))
+        assert var.display_value == ""
+
+    def test_category_env_is_env_var(self):
+        var = VariableSetVariable.from_api_response(self._make_var_response(category="env"))
+        assert var.is_env_var is True
+        assert var.is_terraform_var is False
+
+    def test_category_terraform_is_terraform_var(self):
+        var = VariableSetVariable.from_api_response(self._make_var_response(category="terraform"))
+        assert var.is_terraform_var is True
+        assert var.is_env_var is False
+
+
+class TestVariableSet:
+    """Tests for VariableSet model."""
+
+    def _make_varset_response(self, **overrides):
+        attrs = {
+            "name": "shared-aws-creds",
+            "description": "Shared AWS credentials",
+            "global": False,
+            "var-count": 3,
+            "workspace-count": 5,
+        }
+        attrs.update(overrides)
+        return {
+            "id": "varset-xyz789",
+            "type": "varsets",
+            "attributes": attrs,
+        }
+
+    def test_from_api_response_populates_fields(self):
+        vs = VariableSet.from_api_response(self._make_varset_response())
+        assert vs.id == "varset-xyz789"
+        assert vs.name == "shared-aws-creds"
+        assert vs.description == "Shared AWS credentials"
+        assert vs.global_ is False
+        assert vs.var_count == 3
+        assert vs.workspace_count == 5
+
+    def test_global_varset(self):
+        vs = VariableSet.from_api_response(self._make_varset_response(**{"global": True}))
+        assert vs.global_ is True
+
+    def test_description_defaults_to_none(self):
+        data = self._make_varset_response()
+        del data["attributes"]["description"]
+        vs = VariableSet.from_api_response(data)
+        assert vs.description is None
+
+    def test_model_dump_json_serialisable(self):
+        vs = VariableSet.from_api_response(self._make_varset_response())
+        d = vs.model_dump()
+        assert d["id"] == "varset-xyz789"
+        assert "name" in d


### PR DESCRIPTION
## Summary

- Adds `VariableSet` and `VariableSetVariable` models (`models/varset.py`)
- Adds `VarSetAPI` with `list`, `get_by_name`, `get_variables`, `apply`, `remove` methods (`api/varsets.py`)
- Adds `varset` CLI subcommand with `list`, `show`, `apply`, `remove` — JSON output supported via `--json` (`cli/varset_cmd.py`)
- Wires `TFCClient.varsets` cached property and registers subcommand in `main.py`

## Commands added

```
tfc varset list [-o ORG] [--json]
tfc varset show <name> [-o ORG] [--json]
tfc varset apply <name> --workspace <ws> [-o ORG]
tfc varset remove <name> --workspace <ws> [-o ORG]
```

## Test plan

- [x] 10 unit tests: `VariableSet` and `VariableSetVariable` model parsing, display, properties
- [x] 11 unit tests: `VarSetAPI` — list, get_by_name, get_variables, apply, remove
- [x] 11 unit tests: CLI commands — exit codes, output content, JSON mode, error handling
- [x] 685 tests pass across the full suite (1 pre-existing unrelated failure)
- [x] ruff + mypy + pre-commit all green