### PR TITLE
feat(workspace): run triggers — list, add, remove

### DIFF
--- a/src/terrapyne/api/client.py
+++ b/src/terrapyne/api/client.py
@@ -27,6 +27,7 @@ from terrapyne.core.exceptions import (
 
 if TYPE_CHECKING:
     from terrapyne.api.projects import ProjectAPI
+    from terrapyne.api.run_triggers import RunTriggersAPI
     from terrapyne.api.runs import RunsAPI
     from terrapyne.api.state_versions import StateVersionsAPI
     from terrapyne.api.teams import TeamsAPI
@@ -140,6 +141,13 @@ class TFCClient:
         from terrapyne.api.varsets import VarSetAPI
 
         return VarSetAPI(self)
+
+    @cached_property
+    def run_triggers(self) -> "RunTriggersAPI":
+        """Get run triggers API instance."""
+        from terrapyne.api.run_triggers import RunTriggersAPI
+
+        return RunTriggersAPI(self)
 
     def _log_request(self, method: str, url: str, params: Any = None) -> float:
         if self.debug:

--- a/src/terrapyne/api/run_triggers.py
+++ b/src/terrapyne/api/run_triggers.py
@@ -1,0 +1,68 @@
+"""Run Triggers API methods."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from terrapyne.models.run_trigger import RunTrigger
+
+if TYPE_CHECKING:
+    from terrapyne.api.client import TFCClient
+
+
+class RunTriggersAPI:
+    """Run Triggers API operations."""
+
+    def __init__(self, client: "TFCClient"):
+        self.client = client
+
+    def list(self, workspace_id: str) -> list[RunTrigger]:
+        """List upstream run trigger sources for a workspace.
+
+        Args:
+            workspace_id: The downstream workspace ID
+
+        Returns:
+            List of RunTrigger instances
+        """
+        path = f"/workspaces/{workspace_id}/run-triggers"
+        response = self.client.get(
+            path,
+            params={"filter[run-trigger][type]": "inbound", "include": "source-workspace"},
+        )
+        included = response.get("included", [])
+        return [
+            RunTrigger.from_api_response(item, included=included)
+            for item in response.get("data", [])
+        ]
+
+    def add(self, workspace_id: str, source_workspace_id: str) -> RunTrigger:
+        """Add an upstream run trigger to a workspace.
+
+        Args:
+            workspace_id: The downstream workspace ID
+            source_workspace_id: The upstream (source) workspace ID
+
+        Returns:
+            Created RunTrigger instance
+        """
+        path = f"/workspaces/{workspace_id}/run-triggers"
+        payload: dict[str, Any] = {
+            "data": {
+                "type": "run-triggers",
+                "relationships": {
+                    "sourceable": {"data": {"id": source_workspace_id, "type": "workspaces"}}
+                },
+            }
+        }
+        response = self.client.post(path, json_data=payload)
+        included = response.get("included", [])
+        return RunTrigger.from_api_response(response["data"], included=included)
+
+    def remove(self, run_trigger_id: str) -> None:
+        """Remove a run trigger.
+
+        Args:
+            run_trigger_id: The run trigger ID to delete
+        """
+        self.client.delete(f"/run-triggers/{run_trigger_id}")

--- a/src/terrapyne/cli/triggers_cmd.py
+++ b/src/terrapyne/cli/triggers_cmd.py
@@ -1,0 +1,93 @@
+"""Workspace run triggers CLI commands."""
+
+from typing import cast
+
+import typer
+
+from terrapyne.cli.utils import (
+    console,
+    get_client,
+    handle_cli_errors,
+    resolve_organization,
+    validate_context,
+)
+
+app = typer.Typer(help="Manage workspace run trigger relationships")
+
+
+@app.callback(invoke_without_command=True)
+def _show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
+
+
+@app.command("list")
+@handle_cli_errors
+def triggers_list(
+    ctx: typer.Context,
+    workspace: str | None = typer.Argument(None, help="Downstream workspace name"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+):
+    """List upstream run trigger sources for a workspace."""
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(cast(str, ws_name), org)
+        triggers = client.run_triggers.list(ws.id)
+
+        if not triggers:
+            console.print("[yellow]No run triggers configured for this workspace.[/yellow]")
+            return
+
+        console.print(f"\n[bold]Upstream run triggers for[/bold] {ws_name}:\n")
+        for trigger in triggers:
+            name = trigger.source_workspace_name or trigger.source_workspace_id
+            console.print(f"  • {name}  [dim](id: {trigger.id})[/dim]")
+
+
+@app.command("add")
+@handle_cli_errors
+def triggers_add(
+    ctx: typer.Context,
+    workspace: str | None = typer.Argument(None, help="Downstream workspace name"),
+    source: str = typer.Option(
+        ..., "--source", "-s", help="Upstream workspace name to add as trigger source"
+    ),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+):
+    """Add an upstream workspace as a run trigger source."""
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(cast(str, ws_name), org)
+        source_ws = client.workspaces.get(source, org)
+
+        trigger = client.run_triggers.add(
+            workspace_id=ws.id,
+            source_workspace_id=source_ws.id,
+        )
+
+        source_name = trigger.source_workspace_name or source
+        console.print(f"[green]✓[/green] Added run trigger: {source_name} → {ws_name}")
+        console.print(f"  [dim]trigger id: {trigger.id}[/dim]")
+
+
+@app.command("remove")
+@handle_cli_errors
+def triggers_remove(
+    ctx: typer.Context,
+    trigger_id: str = typer.Option(..., "--trigger-id", "-t", help="Run trigger ID to remove"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+):
+    """Remove a run trigger by its ID."""
+    org = resolve_organization(organization)
+
+    if not force and not typer.confirm(f"Remove run trigger '{trigger_id}'?"):
+        console.print("[yellow]Aborted.[/yellow]")
+        raise typer.Exit(0)
+
+    with get_client(ctx, organization=org) as client:
+        client.run_triggers.remove(run_trigger_id=trigger_id)
+
+    console.print(f"[green]✓[/green] Removed run trigger: {trigger_id}")

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -4,6 +4,7 @@ from typing import Annotated, cast
 
 import typer
 
+from terrapyne.cli import triggers_cmd
 from terrapyne.cli.utils import (
     console,
     emit_json,
@@ -24,6 +25,7 @@ from terrapyne.rendering.rich_tables import (
 )
 
 app = typer.Typer(help="Workspace management commands")
+app.add_typer(triggers_cmd.app, name="triggers")
 
 
 @app.callback(invoke_without_command=True)

--- a/src/terrapyne/models/run_trigger.py
+++ b/src/terrapyne/models/run_trigger.py
@@ -1,0 +1,55 @@
+"""RunTrigger model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from terrapyne.models.utils import parse_iso_datetime
+
+
+class RunTrigger(BaseModel):
+    """Represents a run trigger relationship between two workspaces."""
+
+    id: str
+    source_workspace_id: str
+    source_workspace_name: str | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @classmethod
+    def from_api_response(
+        cls,
+        data: dict[str, Any],
+        included: list[dict[str, Any]] | None = None,
+    ) -> "RunTrigger":
+        """Create a RunTrigger from a TFC API response item.
+
+        Args:
+            data: Single API resource dict (id, type, attributes, relationships)
+            included: Optional list of included resources for name resolution
+
+        Returns:
+            RunTrigger instance
+        """
+        attrs = data.get("attributes", {})
+        relationships = data.get("relationships", {})
+
+        source_ws_id = relationships.get("source-workspace", {}).get("data", {}).get("id", "")
+
+        source_ws_name = None
+        if included and source_ws_id:
+            for item in included:
+                if item.get("type") == "workspaces" and item.get("id") == source_ws_id:
+                    source_ws_name = item.get("attributes", {}).get("name")
+                    break
+
+        return cls.model_construct(
+            id=data["id"],
+            source_workspace_id=source_ws_id,
+            source_workspace_name=source_ws_name,
+            created_at=parse_iso_datetime(attrs.get("created-at")),
+        )

--- a/tests/features/workspace_triggers.feature
+++ b/tests/features/workspace_triggers.feature
@@ -1,0 +1,24 @@
+Feature: Workspace run triggers management
+  As a DevOps engineer using Terraform Cloud
+  I want to inspect and manage workspace-to-workspace run trigger relationships
+  So that I can debug pipeline failures and control automation flows
+
+  Background:
+    Given I have organization "test-org" and workspace "ws-downstream"
+
+  Scenario: Listing upstream run triggers for a workspace
+    When I run "workspace triggers list ws-downstream"
+    Then the output should list the upstream trigger source "upstream-workspace"
+
+  Scenario: Adding a run trigger from an upstream workspace
+    When I add a trigger with source "upstream-workspace"
+    Then the trigger should be created successfully
+
+  Scenario: Removing a run trigger
+    Given there is an existing trigger "rt-abc123"
+    When I remove trigger "rt-abc123"
+    Then the trigger should be removed successfully
+
+  Scenario: Listing triggers shows empty state when no triggers exist
+    When I list triggers for a workspace with no triggers
+    Then the output should indicate no triggers configured

--- a/tests/test_api/test_run_triggers.py
+++ b/tests/test_api/test_run_triggers.py
@@ -1,0 +1,120 @@
+"""Tests for RunTriggersAPI."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from terrapyne.api.run_triggers import RunTriggersAPI
+from terrapyne.models.run_trigger import RunTrigger
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def api(mock_client):
+    return RunTriggersAPI(mock_client)
+
+
+def _trigger_response(
+    id="rt-abc123",
+    source_ws_id="ws-upstream1",
+    source_ws_name="upstream-ws",
+):
+    return {
+        "id": id,
+        "type": "run-triggers",
+        "attributes": {"created-at": "2026-01-15T10:00:00.000Z"},
+        "relationships": {"source-workspace": {"data": {"id": source_ws_id, "type": "workspaces"}}},
+    }
+
+
+def _included_workspace(id="ws-upstream1", name="upstream-ws"):
+    return {"id": id, "type": "workspaces", "attributes": {"name": name}}
+
+
+class TestRunTriggersAPIList:
+    def test_list_calls_get_with_correct_path(self, api, mock_client):
+        mock_client.get.return_value = {"data": [], "included": []}
+        api.list("ws-downstream1")
+        mock_client.get.assert_called_once()
+        call_path = mock_client.get.call_args[0][0]
+        assert call_path == "/workspaces/ws-downstream1/run-triggers"
+
+    def test_list_passes_include_param(self, api, mock_client):
+        mock_client.get.return_value = {"data": [], "included": []}
+        api.list("ws-downstream1")
+        params = (
+            mock_client.get.call_args[1].get("params", {}) or mock_client.get.call_args[0][1]
+            if len(mock_client.get.call_args[0]) > 1
+            else mock_client.get.call_args[1].get("params", {})
+        )
+        assert "filter[run-trigger][type]" in params or "include" in params
+
+    def test_list_returns_run_trigger_objects(self, api, mock_client):
+        mock_client.get.return_value = {
+            "data": [_trigger_response()],
+            "included": [_included_workspace()],
+        }
+        triggers = api.list("ws-downstream1")
+        assert len(triggers) == 1
+        assert isinstance(triggers[0], RunTrigger)
+
+    def test_list_resolves_source_workspace_name(self, api, mock_client):
+        mock_client.get.return_value = {
+            "data": [_trigger_response(source_ws_id="ws-up1", source_ws_name="up-ws")],
+            "included": [_included_workspace(id="ws-up1", name="up-ws")],
+        }
+        triggers = api.list("ws-downstream1")
+        assert triggers[0].source_workspace_name == "up-ws"
+
+    def test_list_returns_empty_for_no_triggers(self, api, mock_client):
+        mock_client.get.return_value = {"data": [], "included": []}
+        assert api.list("ws-downstream1") == []
+
+
+class TestRunTriggersAPIAdd:
+    def test_add_calls_post_with_correct_path(self, api, mock_client):
+        mock_client.post.return_value = {
+            "data": _trigger_response(),
+            "included": [_included_workspace()],
+        }
+        api.add(workspace_id="ws-downstream1", source_workspace_id="ws-upstream1")
+        mock_client.post.assert_called_once()
+        call_path = mock_client.post.call_args[0][0]
+        assert call_path == "/workspaces/ws-downstream1/run-triggers"
+
+    def test_add_sends_correct_payload(self, api, mock_client):
+        mock_client.post.return_value = {
+            "data": _trigger_response(),
+            "included": [_included_workspace()],
+        }
+        api.add(workspace_id="ws-downstream1", source_workspace_id="ws-upstream1")
+        json_data = (
+            mock_client.post.call_args[1].get("json_data") or mock_client.post.call_args[0][1]
+        )
+        assert json_data["data"]["type"] == "run-triggers"
+        assert json_data["data"]["relationships"]["sourceable"]["data"]["id"] == "ws-upstream1"
+        assert json_data["data"]["relationships"]["sourceable"]["data"]["type"] == "workspaces"
+
+    def test_add_returns_run_trigger(self, api, mock_client):
+        mock_client.post.return_value = {
+            "data": _trigger_response(),
+            "included": [_included_workspace()],
+        }
+        trigger = api.add(workspace_id="ws-downstream1", source_workspace_id="ws-upstream1")
+        assert isinstance(trigger, RunTrigger)
+        assert trigger.id == "rt-abc123"
+
+
+class TestRunTriggersAPIRemove:
+    def test_remove_calls_delete_with_correct_path(self, api, mock_client):
+        api.remove(run_trigger_id="rt-abc123")
+        mock_client.delete.assert_called_once_with("/run-triggers/rt-abc123")
+
+    def test_remove_returns_none(self, api, mock_client):
+        mock_client.delete.return_value = None
+        result = api.remove(run_trigger_id="rt-abc123")
+        assert result is None

--- a/tests/test_cli/test_workspace_triggers.py
+++ b/tests/test_cli/test_workspace_triggers.py
@@ -1,0 +1,211 @@
+"""CLI tests for workspace triggers commands."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+from typer.testing import CliRunner
+
+from terrapyne.cli.main import app
+from terrapyne.models.run_trigger import RunTrigger
+
+runner = CliRunner()
+
+
+# ============================================================================
+# Shared context fixture
+# ============================================================================
+
+
+@pytest.fixture
+def ctx():
+    return {}
+
+
+# ============================================================================
+# Scenario: Listing upstream run triggers for a workspace
+# ============================================================================
+
+
+@scenario("../features/workspace_triggers.feature", "Listing upstream run triggers for a workspace")
+def test_list_triggers():
+    pass
+
+
+@given('I have organization "test-org" and workspace "ws-downstream"')
+def given_org_and_workspace(ctx):
+    ctx["org"] = "test-org"
+    ctx["workspace"] = "ws-downstream"
+
+
+@when('I run "workspace triggers list ws-downstream"')
+def when_list_triggers(ctx):
+    trigger = MagicMock(spec=RunTrigger)
+    trigger.id = "rt-abc123"
+    trigger.source_workspace_id = "ws-up1"
+    trigger.source_workspace_name = "upstream-workspace"
+    trigger.created_at = None
+
+    with (
+        patch("terrapyne.cli.utils.resolve_organization", return_value="test-org"),
+        patch("terrapyne.cli.utils.validate_context", return_value=("test-org", "ws-downstream")),
+        patch("terrapyne.api.client.TFCClient") as mock_cls,
+    ):
+        mock_instance = MagicMock()
+        mock_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.workspaces.get.return_value = MagicMock(id="ws-downstream-id")
+        mock_instance.run_triggers.list.return_value = [trigger]
+
+        result = runner.invoke(
+            app, ["workspace", "triggers", "list", "ws-downstream", "--organization", "test-org"]
+        )
+        ctx["result"] = result
+
+
+@then('the output should list the upstream trigger source "upstream-workspace"')
+def then_output_lists_trigger(ctx):
+    assert ctx["result"].exit_code == 0, ctx["result"].output
+    assert "upstream-workspace" in ctx["result"].output
+
+
+# ============================================================================
+# Scenario: Adding a run trigger from an upstream workspace
+# ============================================================================
+
+
+@scenario(
+    "../features/workspace_triggers.feature", "Adding a run trigger from an upstream workspace"
+)
+def test_add_trigger():
+    pass
+
+
+@when('I add a trigger with source "upstream-workspace"')
+def when_add_trigger(ctx):
+    trigger = MagicMock(spec=RunTrigger)
+    trigger.id = "rt-new1"
+    trigger.source_workspace_id = "ws-up1"
+    trigger.source_workspace_name = "upstream-workspace"
+
+    with (
+        patch("terrapyne.cli.utils.resolve_organization", return_value="test-org"),
+        patch("terrapyne.cli.utils.validate_context", return_value=("test-org", "ws-downstream")),
+        patch("terrapyne.api.client.TFCClient") as mock_cls,
+    ):
+        mock_instance = MagicMock()
+        mock_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.workspaces.get.return_value = MagicMock(id="ws-downstream-id")
+        upstream_ws = MagicMock(id="ws-up1")
+        mock_instance.workspaces.get.side_effect = [
+            MagicMock(id="ws-downstream-id"),
+            upstream_ws,
+        ]
+        mock_instance.run_triggers.add.return_value = trigger
+
+        result = runner.invoke(
+            app,
+            [
+                "workspace",
+                "triggers",
+                "add",
+                "ws-downstream",
+                "--source",
+                "upstream-workspace",
+                "--organization",
+                "test-org",
+            ],
+        )
+        ctx["result"] = result
+
+
+@then("the trigger should be created successfully")
+def then_trigger_created(ctx):
+    assert ctx["result"].exit_code == 0, ctx["result"].output
+    assert "upstream-workspace" in ctx["result"].output or "trigger" in ctx["result"].output.lower()
+
+
+# ============================================================================
+# Scenario: Removing a run trigger
+# ============================================================================
+
+
+@scenario("../features/workspace_triggers.feature", "Removing a run trigger")
+def test_remove_trigger():
+    pass
+
+
+@given('there is an existing trigger "rt-abc123"')
+def given_existing_trigger(ctx):
+    ctx["trigger_id"] = "rt-abc123"
+
+
+@when('I remove trigger "rt-abc123"')
+def when_remove_trigger(ctx):
+    with (
+        patch("terrapyne.cli.utils.resolve_organization", return_value="test-org"),
+        patch("terrapyne.api.client.TFCClient") as mock_cls,
+    ):
+        mock_instance = MagicMock()
+        mock_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.run_triggers.remove.return_value = None
+
+        result = runner.invoke(
+            app,
+            [
+                "workspace",
+                "triggers",
+                "remove",
+                "--trigger-id",
+                "rt-abc123",
+                "--organization",
+                "test-org",
+                "--force",
+            ],
+        )
+        ctx["result"] = result
+
+
+@then("the trigger should be removed successfully")
+def then_trigger_removed(ctx):
+    assert ctx["result"].exit_code == 0, ctx["result"].output
+
+
+# ============================================================================
+# Scenario: Listing triggers shows empty state
+# ============================================================================
+
+
+@scenario(
+    "../features/workspace_triggers.feature",
+    "Listing triggers shows empty state when no triggers exist",
+)
+def test_list_triggers_empty():
+    pass
+
+
+@when("I list triggers for a workspace with no triggers")
+def when_list_no_triggers(ctx):
+    with (
+        patch("terrapyne.cli.utils.resolve_organization", return_value="test-org"),
+        patch("terrapyne.cli.utils.validate_context", return_value=("test-org", "ws-downstream")),
+        patch("terrapyne.api.client.TFCClient") as mock_cls,
+    ):
+        mock_instance = MagicMock()
+        mock_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.workspaces.get.return_value = MagicMock(id="ws-downstream-id")
+        mock_instance.run_triggers.list.return_value = []
+
+        result = runner.invoke(
+            app, ["workspace", "triggers", "list", "ws-downstream", "--organization", "test-org"]
+        )
+        ctx["result"] = result
+
+
+@then("the output should indicate no triggers configured")
+def then_no_triggers(ctx):
+    assert ctx["result"].exit_code == 0, ctx["result"].output
+    assert "No" in ctx["result"].output or "no" in ctx["result"].output

--- a/tests/unit/test_run_trigger_model.py
+++ b/tests/unit/test_run_trigger_model.py
@@ -1,0 +1,57 @@
+"""Tests for the RunTrigger model."""
+
+from terrapyne.models.run_trigger import RunTrigger
+
+
+class TestRunTriggerModel:
+    """Unit tests for RunTrigger."""
+
+    def _api_response(
+        self,
+        id="rt-abc123",
+        source_workspace_id="ws-upstream1",
+        source_workspace_name="upstream-workspace",
+        created_at="2026-01-15T10:00:00.000Z",
+    ):
+        return {
+            "id": id,
+            "type": "run-triggers",
+            "attributes": {
+                "created-at": created_at,
+            },
+            "relationships": {
+                "source-workspace": {"data": {"id": source_workspace_id, "type": "workspaces"}}
+            },
+            "included": [
+                {
+                    "id": source_workspace_id,
+                    "type": "workspaces",
+                    "attributes": {"name": source_workspace_name},
+                }
+            ],
+        }
+
+    def test_from_api_response_sets_id(self):
+        data = self._api_response()
+        trigger = RunTrigger.from_api_response(data, included=data["included"])
+        assert trigger.id == "rt-abc123"
+
+    def test_from_api_response_sets_source_workspace_id(self):
+        data = self._api_response()
+        trigger = RunTrigger.from_api_response(data, included=data["included"])
+        assert trigger.source_workspace_id == "ws-upstream1"
+
+    def test_from_api_response_sets_source_workspace_name_from_included(self):
+        data = self._api_response()
+        trigger = RunTrigger.from_api_response(data, included=data["included"])
+        assert trigger.source_workspace_name == "upstream-workspace"
+
+    def test_from_api_response_source_workspace_name_none_when_no_included(self):
+        data = self._api_response()
+        trigger = RunTrigger.from_api_response(data, included=[])
+        assert trigger.source_workspace_name is None
+
+    def test_from_api_response_sets_created_at(self):
+        data = self._api_response()
+        trigger = RunTrigger.from_api_response(data, included=data["included"])
+        assert trigger.created_at is not None


### PR DESCRIPTION
## Summary

- Adds `RunTrigger` model with source workspace name resolution from TFC API `included` data
- Adds `RunTriggersAPI` with `list`, `add`, and `remove` operations
- Registers `client.run_triggers` as a cached property on `TFCClient`
- Adds `tfc workspace triggers` sub-command group with three commands:
  - `list <ws>` — list upstream trigger sources for a workspace
  - `add <ws> --source <upstream-ws>` — add an upstream workspace as a trigger source
  - `remove --trigger-id <id>` — remove a trigger by ID

## Test plan

- [ ] `tests/unit/test_run_trigger_model.py` — 5 model unit tests (from_api_response, field mapping, name resolution)
- [ ] `tests/test_api/test_run_triggers.py` — 10 API unit tests (list/add/remove payload/response)
- [ ] `tests/test_cli/test_workspace_triggers.py` — 4 BDD CLI scenario tests
- [ ] Full suite: 678 passed, no regressions