### PR TITLE
fix(run): surface apply-log error when plan succeeds

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,120 +1,330 @@
-# TODO — Exploratory Testing Findings
+# TODO — Terrapyne Product Backlog
 
-Bugs and improvements found during exploratory testing against live TFC.
+Bugs, gaps, and improvements. Sources:
+- Exploratory testing against live TFC
+- Product fitness appraisal against TFC API model (April 2026)
 
 ## Development Requirements
+
 All new features and fixes must strictly follow:
 1. **Red/Green TDD**: Write a failing test first, make it pass with minimal code, then refactor.
 2. **Adzic BDD**: Use Gojko Adzic's Specification by Example principles to write `.feature` files.
-3. **ACP (Atomic Commit Protocol)**: Every commit must be atomic, verified, and use Conventional Commits.
+3. **ACP (Atomic Commit Protocol)**: Every commit must be atomic, verified, and uses Conventional Commits.
 
 ## Test Environment
-For evaluating live TFC behavior, use the following workspace directory:
+
+For evaluating live TFC behaviour, use:
 - `/home/unop/oneTakeda/terraform-dce-developer-ShalomBhooshi/iac/dev`
 
-## Priority Matrix (WSJF-based)
+---
 
-**Impact (Value)**: 🔴 High (4), 🟡 Medium (2), 🟢 Low (1)
-**Effort (Size)**: S (1), M (2), L (3)
-**Score (WSJF)**: Impact / Effort
+## Priority Matrix (WSJF)
 
-| # | Finding | Impact | Effort | Score | Status |
+**Impact**: 🔴 High (4), 🟡 Medium (2), 🟢 Low (1)
+**Effort**: S=1, M=2, L=3
+**WSJF** = Impact / Effort
+
+| # | Finding | Impact | Effort | WSJF | Status |
 |---|---|---|---|---|---|
-| 17 | [BLOCKER] Restore test coverage to 65% (PR #36 Regression) | 🔴 | S | 4.0 | ✅ |
-| 18 | [BLOCKER] Fix Cost Estimate Regression (PR #36 logic error) | 🔴 | S | 4.0 | ✅ |
-| 19 | [BLOCKER] Remove broad exception silencing in `workspace_cmd.py` | 🔴 | S | 4.0 | ✅ |
-| 10 | Enhanced Run Lifecycle (Trigger types, Queue wait, Approvals) | 🔴 | M | 2.0 | TODO |
-| 14 | Restore test coverage minimum `fail-under` to 80% (Long-term goal) | 🔴 | M | 2.0 | TODO |
-| 20 | [MINOR] Use `RunStatus` enum instead of hardcoded strings | 🟡 | S | 2.0 | ✅ |
-| 9 | `--raw` flag for `state outputs` for single unquoted values | 🟡 | S | 2.0 | ✅ |
-| 13.1 | `--json` output for `workspace show` command | 🟡 | S | 2.0 | TODO |
-| 13.2 | `--json` output for `project show` command | 🟡 | S | 2.0 | TODO |
-| 13.3 | Decomposed: Workspace enrichment (health, active runs, VCS metadata) | 🟡 | M | 1.33 | TODO |
-| 13.4 | Decomposed: Log streaming for run follow | 🟡 | M | 1.33 | TODO |
-| 21 | [MINOR] Consolidate `workspace_show` API calls (Optimization) | 🟡 | M | 1.0 | TODO |
-| 22 | [MINOR] Add strict validation to `Run.from_api_response` | 🟡 | M | 1.0 | ✅ |
-| 6 | `--debug` flag for API call tracing | 🟡 | M | 1.0 | TODO |
-| 1c | `tfc project show` 'single glance' snapshot | 🟡 | M | 1.0 | TODO |
-| 8 | Local file-based response cache | 🟢 | L | 0.3 | TODO |
-
-## Decomposition Notes (April 13, 2026)
-
-The original "workspace enrichment" PR had become a "God PR" with 20+ commits mixing multiple concerns. It's been decomposed into atomic PRs:
-
-| Original | Decomposed | Scope |
-|----------|-----------|-------|
-| PR #43 | #13.1, #13.2 | JSON output (high priority, small effort) |
-| PR #43 | #13.3 | Workspace health enrichment (medium priority) |
-| PR #43 | #13.4 | Log streaming (medium priority, can be separate) |
-| PR #44 | N/A | Code quality merged into PR #45 |
-
-**Strategy**: Implement #13.1, #13.2 first (quick wins, high value). Then reassess #13.3, #13.4 based on user feedback.
-
-## Task Details (Intent, Context, Success Criteria)
-
-### 17. Restore Test Coverage Threshold (🏆)
-**Intent**: Re-establish the quality gate for the codebase after a temporary drop during feature development.
-**Context**: PR #36 dropped coverage threshold from 65% to 25%. This masks untested code in the new enrichment feature.
-**Success Criteria**: `pyproject.toml` has `cov-fail-under=65` and all tests pass with coverage verification.
-
-### 18. Fix Cost Estimate Regression (🏆)
-**Intent**: Ensure the "latest cost estimate" logic is robust against pending or failed runs.
-**Context**: PR #36 changed `get_latest_cost_estimate` to only look at the single latest run. If that run hasn't finished cost estimation, it returns `None`.
-**Success Criteria**: The logic searches the last ~10 runs for a finished cost estimate, restoring the behavior that allowed users to see the most recent valid cost data even if a new run is in progress.
-
-### 19. Remove Broad Exception Silencing (🏆)
-**Intent**: Prevent "silent failures" in the CLI and improve observability for users.
-**Context**: `workspace_cmd.py` used blanket `except Exception as e` which caught everything.
-**Success Criteria**: Replace with specific exception handling (e.g., `httpx.HTTPStatusError`) and ensure critical failures still halt execution or provide clear diagnostic information.
-
-### 10. Enhanced Run Lifecycle (⭐)
-**Intent**: Provide a robust, CI/CD-friendly interface for triggering and monitoring runs.
-**Context**: Users needed better control over run types (plan-only, auto-apply, refresh, destroy) and queue management.
-**Success Criteria**:
-- Support for `--wait` (block until workspace available) and `--discard-older` (clear queue).
-- Support for `--debug-run` (TFC debugging-mode).
-- Explicit identification of run types in CLI output.
-- Smart "Story" for shell return: Exit `0` when paused for approval if auto-apply is off.
-
-### 20. Use `RunStatus` Enum for Filtering (⭐)
-**Intent**: Eliminate magic strings and synchronize CLI filtering with the core domain model.
-**Context**: Active run filtering in `workspace_cmd.py` used a hardcoded comma-separated string of statuses.
-**Success Criteria**: The active status list is derived from the `RunStatus` enum, ensuring that any future status changes in the domain model automatically propagate to the CLI.
-
-### 21. Consolidate `workspace_show` API calls (⭐)
-**Intent**: Reduce command latency by minimizing round-trips to the TFC API.
-**Context**: Currently, `workspace_show` makes one call for the latest run (including VCS) and another for active counts.
-**Success Criteria**: Fetch a window of runs (e.g., 20) in a single call and calculate active counts and latest run details from that single response.
-
-### 22. Strict Validation for `Run` Model (⭐)
-**Intent**: Ensure data integrity when consuming external API payloads.
-**Context**: `Run.from_api_response` used `model_construct`, which is fast but skips type/presence validation.
-**Success Criteria**: Implement validation for critical fields (id, status) while maintaining the factory pattern for relationship extraction.
-
-### 9. Raw State Outputs (⭐)
-**Intent**: Enable easy shell-pipeline integration for terraform outputs.
-**Context**: Users needed to pipe single output values to other commands without quotes or extra formatting.
-**Success Criteria**: `tfc state outputs NAME --raw` returns the unquoted literal value of the output.
-
-### 13. JSON Structured Output (⭐)
-**Intent**: Support machine-readable consumption of dashboard information.
-**Context**: Automation tools need the same high-level info shown in tables but in JSON format.
-**Success Criteria**: `--json` flag implemented for `workspace show` and `project show` providing full structured data.
-
-### 6. API Debug Tracing (⭐)
-**Intent**: Provide developers with deep visibility into TFC API interactions.
-**Context**: Troubleshooting complex interactions or "silent" API errors.
-**Success Criteria**: `--debug` global flag captures and prints all outgoing requests and incoming responses (headers, bodies).
-
-### 1c. Project Snapshot (⭐)
-**Intent**: Provide a 'single glance' health check for entire projects.
-**Context**: Managing dozens of workspaces requires higher-level aggregation.
-**Success Criteria**: `tfc project show` includes total workspace counts and an aggregate count of active runs across the project.
-
-### 8. Response Caching (⭐)
-**Intent**: Speed up read-heavy operations and avoid API rate limits.
-**Context**: Commands like `project show` or `list` often repeat the same queries.
-**Success Criteria**: Local file-based caching implemented in `TFCClient` with configurable TTL.
+| **BUGS** |
+| B1 | `_handle_response_error` catches wrong exception type | 🔴 | S | 4.0 | TODO |
+| B2 | Retry-on-mutation: POST/PATCH/DELETE retry `TFCAPIError` (unsafe) | 🔴 | S | 4.0 | TODO |
+| B3 | `paginate_with_meta` `included` leaks only last page | 🟡 | S | 2.0 | TODO |
+| B4 | `project.list()` wildcard search strips `*` but doesn't post-filter | 🟢 | S | 1.0 | TODO |
+| **COMPLETED** |
+| 17 | Restore test coverage to 65% | 🔴 | S | 4.0 | ✅ |
+| 18 | Fix cost estimate regression | 🔴 | S | 4.0 | ✅ |
+| 19 | Remove broad exception silencing in `workspace_cmd.py` | 🔴 | S | 4.0 | ✅ |
+| 20 | Use `RunStatus` enum instead of hardcoded strings | 🟡 | S | 2.0 | ✅ |
+| 9  | `--raw` flag for `state outputs` | 🟡 | S | 2.0 | ✅ |
+| 13.1 | `--json` output for `workspace show` | 🟡 | S | 2.0 | ✅ |
+| 13.2 | `--json` output for `project show` | 🟡 | S | 2.0 | ✅ |
+| 13.3 | Workspace health enrichment (active runs, VCS metadata) | 🟡 | M | 1.33 | ✅ |
+| 13.4 | Log streaming for `run follow` | 🟡 | M | 1.33 | ✅ |
+| 21 | Consolidate `workspace show` API calls | 🟡 | M | 1.0 | ✅ |
+| 22 | Strict validation for `Run.from_api_response` | 🟡 | M | 1.0 | ✅ |
+| 6  | `--debug` flag for API call tracing | 🟡 | M | 1.0 | ✅ |
+| 1c | `tfc project show` project snapshot | 🟡 | M | 1.0 | ✅ |
+| 8  | Local file-based response cache with TTL | 🟢 | L | 0.3 | ✅ |
+| 10 | Enhanced run lifecycle (trigger types, queue wait, approvals) | 🔴 | M | 2.0 | ✅ |
+| **COVERAGE** |
+| 14 | Restore test coverage minimum to 80% (long-term goal) | 🔴 | M | 2.0 | TODO |
+| **CORRECTNESS** |
+| C1 | `cloud` block backend detection (Terraform ≥ 1.1) | 🔴 | M | 2.0 | TODO |
+| C2 | `run plan` semantics mismatch — not a true speculative plan | 🟡 | M | 1.0 | TODO |
+| C3 | `StateVersionsAPI.list()` needless workspace round-trip | 🟢 | S | 1.0 | TODO |
+| **NEW FEATURES** |
+| F1 | Variable Sets (`/varsets`) — org/project-scoped variables | 🔴 | L | 1.33 | TODO |
+| F2 | Run Triggers — workspace-to-workspace automation | 🔴 | L | 1.33 | TODO |
+| F3 | `workspace create` / `workspace delete` commands | 🔴 | M | 2.0 | TODO |
+| F4 | Workspace notifications (webhook/Slack config) | 🟡 | M | 1.0 | TODO |
+| F5 | Policy sets / Sentinel outcome reporting | 🟡 | M | 1.0 | TODO |
+| F6 | Private registry query (modules + providers) | 🟡 | M | 1.0 | TODO |
+| F7 | Agent pools — list and show self-hosted agents | 🟡 | M | 1.0 | TODO |
+| F8 | SSH keys / VCS OAuth token management | 🟢 | L | 0.33 | TODO |
 
 ---
-*(Task 14 details remain in the backlog)*
+
+## Task Details
+
+### B1 — `_handle_response_error` catches wrong exception type
+
+**Intent**: Fix silent failure in HTTP error handling — errors currently propagate as raw `httpx.HTTPStatusError` instead of domain exceptions.
+
+**Context**: `_handle_response_error` calls `response.raise_for_status()` and catches `TFCAPIError`. But `httpx` raises `httpx.HTTPStatusError`, not `TFCAPIError`. The catch block is unreachable; all HTTP errors bypass domain exception mapping entirely.
+
+**Success Criteria**:
+- `except httpx.HTTPStatusError` used instead of `except TFCAPIError`
+- `TFCAuthenticationError`, `TFCNotFoundError`, `TFCConflictError`, `TFCRateLimitError`, `TFCServerError` are raised correctly on 401/403/404/409/429/5xx
+- Existing tests updated/extended to verify the mapping
+
+---
+
+### B2 — Retry-on-mutation is unsafe
+
+**Intent**: Prevent duplicate resource creation or double-apply from over-eager retry on non-idempotent calls.
+
+**Context**: `post`, `patch`, and `delete` all retry on `TFCAPIError`. A run creation or variable update that times out server-side but returns a 500 could be retried, creating duplicates. Retry should only apply to idempotent operations or be narrowed to `TFCServerError` on mutations.
+
+**Success Criteria**:
+- `post` / `patch` / `delete` retry only on `TFCServerError` (5xx), not on generic `TFCAPIError`
+- Or: mutation methods have no retry decorator and callers handle retries explicitly where safe
+- Test covers retry-not-triggered scenario for 409 on POST
+
+---
+
+### B3 — `paginate_with_meta` `included` leaks only last page
+
+**Intent**: Ensure relationship data (project names, run details) is correctly resolved for all pages, not just the last one fetched.
+
+**Context**: `ResponseIterator.included` is overwritten on each page fetch. Workspace listings spanning multiple pages lose project name resolution for workspaces on page 2+.
+
+**Success Criteria**:
+- `included` accumulates across all pages (or is merged per item)
+- `workspace list` with >100 workspaces correctly resolves project names throughout
+
+---
+
+### B4 — Project wildcard search false positives
+
+**Intent**: `project find 10234-*` should return only projects whose names start with `10234-`, not every project containing `10234`.
+
+**Context**: The wildcard is stripped to a bare substring for the `q=` param. No post-filtering is applied, so `my-10234-project` is included in results for `10234-*`.
+
+**Success Criteria**:
+- After fetching API results, apply Python `fnmatch` filtering on the pattern
+- Works for prefix (`10234-*`), suffix (`*-MAN`), and contains (`*235*`) patterns
+
+---
+
+### C1 — `cloud` block backend detection
+
+**Intent**: Auto-detect org/workspace from modern Terraform configurations that use the `cloud` block.
+
+**Context**: `backend "remote"` was soft-deprecated in Terraform 1.1 in favour of the `cloud` block. Most contemporary codebases use `cloud`. The current `backend.py` regex and HCL parser only handle `backend "remote"`, so context auto-detection silently fails for modern configs.
+
+```hcl
+terraform {
+  cloud {
+    organization = "my-org"
+    workspaces {
+      name = "my-workspace"
+    }
+  }
+}
+```
+
+**Success Criteria**:
+- `detect_backend()` parses `cloud` blocks (both HCL and regex fallback)
+- Returns a `RemoteBackend` with the same fields as today
+- Existing `backend "remote"` tests still pass
+- New fixture `.tf` files cover `cloud` block variants (name, tags, prefix)
+
+---
+
+### C2 — `run plan` semantics mismatch
+
+**Intent**: Align the `run plan` command with TFC's concept of a speculative plan.
+
+**Context**: `run plan` creates a confirmable plan run (`auto_apply=False`). TFC's true speculative plan is a read-only, non-confirmable plan attached to a `configuration-version` with `speculative: true`. These are different: a speculative plan cannot be applied; the current command's output *can* be applied via `run apply`.
+
+**Options**:
+1. Rename `run plan` to `run queue` (plan queued for potential apply)
+2. Add a separate `run speculative` command via the configuration-version API
+3. Add a `--speculative` flag to `run plan` / `run trigger`
+
+**Success Criteria** (option 3 recommended):
+- `run trigger --speculative` creates a true speculative plan via configuration-version API
+- Existing `run plan` behaviour preserved but documented as "queued plan"
+- Help text distinguishes the two modes
+
+---
+
+### C3 — `StateVersionsAPI.list()` unnecessary round-trip
+
+**Intent**: Remove redundant workspace lookup when listing state versions by workspace ID.
+
+**Context**: TFC's `/state-versions` endpoint accepts `filter[workspace][id]` directly. The current implementation fetches the workspace by ID first to get its name, then uses `filter[workspace][name]`. This adds a round-trip.
+
+**Success Criteria**:
+- `filter[workspace][id]` used when a `workspace_id` is provided
+- Workspace name resolution only happens when `workspace_name` is explicitly needed
+- Existing `state list` behaviour unchanged
+
+---
+
+### F1 — Variable Sets
+
+**Intent**: Allow listing, inspecting, and applying variable sets — the primary mechanism for shared variables at org/project scope in TFC.
+
+**Context**: Variable Sets (`/varsets`) are one of the most heavily used TFC primitives in multi-workspace organisations. Without them, the tool cannot support common patterns like shared AWS credentials or shared environment configs.
+
+**Success Criteria**:
+- `tfc varset list` — list org-level variable sets
+- `tfc varset show <name>` — show variables in a set
+- `tfc varset apply <name> --workspace <ws>` — apply set to a workspace
+- `tfc varset remove <name> --workspace <ws>` — detach set from workspace
+- Models: `VariableSet`, `VariableSetVariable`
+- JSON output supported
+
+---
+
+### F2 — Run Triggers
+
+**Intent**: Enable inspection and management of workspace-to-workspace run trigger relationships.
+
+**Context**: Run triggers are central to TFC pipeline patterns — workspace B re-plans when workspace A applies successfully. Without visibility, debugging pipeline failures is blind.
+
+**Success Criteria**:
+- `tfc workspace triggers list <ws>` — list upstream trigger sources for a workspace
+- `tfc workspace triggers add <ws> --source <upstream-ws>` — add a trigger
+- `tfc workspace triggers remove <ws> --source <upstream-ws>` — remove a trigger
+- Model: `RunTrigger`
+
+---
+
+### F3 — `workspace create` / `workspace delete`
+
+**Intent**: Complete the workspace lifecycle — bootstrapping and teardown are as common as inspection.
+
+**Context**: `workspace clone` exists but there's no bare create or delete. CI pipelines that provision ephemeral workspaces (e.g., per-PR environments) have no way to use the tool end-to-end.
+
+**Success Criteria**:
+- `tfc workspace create <name> --project <p> --tf-version <v> --execution-mode <m>`
+- `tfc workspace delete <name> [--force]` with confirmation guard
+- `workspace create` supports `--vcs-repo`, `--oauth-token-id`, `--working-dir` for VCS-connected workspaces
+- Integration with existing `workspace clone` internals where possible
+
+---
+
+### F4 — Workspace Notifications
+
+**Intent**: Inspect and configure notification triggers (Slack, webhook, email, PagerDuty) on workspaces.
+
+**Success Criteria**:
+- `tfc workspace notifications list <ws>`
+- `tfc workspace notifications add <ws> --type slack --url <url> --triggers apply,errored`
+- `tfc workspace notifications remove <ws> <notification-id>`
+
+---
+
+### F5 — Policy Set Outcomes
+
+**Intent**: Surface Sentinel/OPA policy check results in run output without requiring the TFC UI.
+
+**Success Criteria**:
+- `run show` includes policy check outcomes when present (pass/fail/override per policy)
+- `tfc policy list` — list policy sets scoped to a workspace or project
+- JSON output supported
+
+---
+
+### F6 — Private Registry Query
+
+**Intent**: Allow platform teams to discover modules and providers in the private registry without the UI.
+
+**Success Criteria**:
+- `tfc registry modules list` — list private modules with version info
+- `tfc registry providers list` — list private providers
+- `tfc registry modules show <namespace>/<name>/<provider>` — show versions and readme
+
+---
+
+### F7 — Agent Pools
+
+**Intent**: Provide visibility into self-hosted agent pools and agent status.
+
+**Success Criteria**:
+- `tfc agent list` — list agent pools and agents with status (idle/busy/errored)
+- `tfc agent show <pool-id>` — show pool details and connected agents
+- JSON output supported
+
+---
+
+### F8 — SSH Keys / VCS OAuth Tokens
+
+**Intent**: Support workspace provisioning workflows that require attaching SSH keys or VCS tokens.
+
+**Success Criteria**:
+- `tfc vcs tokens list` — list OAuth tokens in the org
+- `tfc ssh list` / `tfc ssh show <id>` — list/inspect SSH keys
+- Used internally by `workspace create --vcs-repo` (F3 dependency)
+
+---
+
+*(Task 14 — restore coverage to 80% — remains a long-term goal, tracked separately)*
+
+---
+
+## Documentation & Architecture Audit (April 2026)
+
+### Priority Matrix Additions
+
+| # | Finding | Impact | Effort | WSJF | Status |
+|---|---|---|---|---|---|
+| **DOCS** |
+| D1 | Fix broken docs links in AGENTS.md & deprecate GEMINI.md | 🔴 | S | 4.0 | TODO |
+| D2 | CLI reference lists non-existent `workspace health` | 🟡 | S | 2.0 | TODO |
+| D3 | SDK reference missing managers (state_versions, vcs) | 🟡 | S | 2.0 | TODO |
+| D4 | SDK models table incomplete | 🟡 | S | 2.0 | TODO |
+| D5 | `plan-parser.md` is a planning artifact, not explanation | 🟡 | S | 2.0 | TODO |
+| D6 | ADR-004 Gherkin examples diverged from feature file | 🟡 | S | 2.0 | TODO |
+| D8 | How-to SDK example: clarify Iterator and nullable total | 🟢 | S | 1.0 | TODO |
+| **ARCH** |
+| A3 | `emit_json` imports `unittest.mock.Mock` in prod | 🟡 | S | 2.0 | TODO |
+| A4 | `parse-plan` CLI spawns local Terraform binary | 🟡 | S | 2.0 | TODO |
+| A6 | `model_construct()` skips validation across all models | 🟡 | M | 1.33 | TODO |
+| A7 | `Workspace.latest_run` Any type (circular ref) | 🟡 | S | 2.0 | TODO |
+| A8 | Three uncoordinated `Console()` instances | 🟡 | M | 1.33 | TODO |
+| A9 | `Terraform` and `TFCClient` conflated in top-level | 🟡 | M | 1.0 | TODO |
+| A10| `RunStatus.get_active_statuses()` returns `list[str]` | 🟢 | S | 1.0 | TODO |
+| A11| Inline `RunStatus` import in `workspace_show` | 🟢 | S | 1.0 | TODO |
+| A12| `run_cmd.py` decomposition (852 lines) | 🟢 | L | 0.3 | TODO |
+| A13| `paginate()` and `paginate_with_meta()` divergent | 🟢 | M | 0.5 | TODO |
+| A14| Domain errors defined in API layer | 🟢 | S | 1.0 | TODO |
+| A15| `utils/` is an unconstrained catch-all | 🟢 | L | 0.3 | TODO |
+| **FEAT** |
+| D7 | Promote `workspace health` to real CLI command | 🟡 | M | 1.33 | TODO |
+
+### Task Details (Audit)
+
+#### D1 — Fix AGENTS.md links & GEMINI.md deprecation
+- **Context**: Guide paths moved in Diataxis restructure but AGENTS.md was not updated. GEMINI.md has duplicate/divergent agent instructions.
+- **Action**: Update links to `docs/how-to/` and `docs/explanation/`. Merge unique Ralph/Bart/ACP rules from GEMINI.md into AGENTS.md. Delete GEMINI.md.
+
+#### A4 — parse-plan binary dependency
+- **Context**: `tfc run parse-plan` currently creates a `Terraform` object which fails if the binary is missing, even though the parser is pure Python.
+- **Action**: Call `PlanParser` directly from `terrapyne.sdk.plan_parser`.
+
+#### A6 — model_validate instead of model_construct
+- **Context**: Performance "optimization" that bypasses Pydantic validation on API ingestion.
+- **Action**: Re-enable validation to catch malformed TFC responses early.
+
+#### A7 — Workspace.latest_run type hint
+- **Context**: Uses `Any` to avoid circular import.
+- **Action**: Use `from __future__ import annotations` and `if TYPE_CHECKING: from ...run import Run`.
+
+#### A12 — run_cmd.py decomposition
+- **Context**: 850 lines mixing CLI glue with complex log streaming and polling state machines.
+- **Action**: Extract `RunMonitor` or move polling logic to `RunsAPI`.
+

--- a/src/terrapyne/api/runs.py
+++ b/src/terrapyne/api/runs.py
@@ -1,6 +1,7 @@
 """TFC Runs API."""
 
 import builtins
+import re
 import time
 from collections.abc import Callable
 from typing import Any
@@ -9,6 +10,8 @@ from terrapyne.core.exceptions import TFCAuthenticationError, TFCNotFoundError
 from terrapyne.models.apply import Apply
 from terrapyne.models.plan import Plan
 from terrapyne.models.run import Run
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class RunsAPI:
@@ -339,6 +342,40 @@ class RunsAPI:
         except (TFCNotFoundError, TFCAuthenticationError):
             # Logs might not be ready yet
             return ""
+
+    def get_error_summary(self, run: Run) -> str:
+        """Extract the Terraform error text from an errored run.
+
+        When the plan stage completed successfully (plan_status == "finished")
+        the failure occurred during apply — so the apply log is fetched.
+        Otherwise the error is in the plan log.
+
+        Falls back to run.message when no log is available or no Error: lines
+        are found (e.g. the run was cancelled before Terraform produced output).
+
+        Args:
+            run: An errored Run instance, ideally with plan_status populated
+                 via the plans included sideload.
+
+        Returns:
+            Extracted error lines joined by newline, or run.message as fallback.
+        """
+        fallback = run.message or run.id
+
+        if not run.plan_id:
+            return fallback
+
+        if run.plan_status == "finished":
+            # Plan succeeded — error is in the apply stage
+            raw = self.get_apply_logs(run.apply_id) if run.apply_id else ""
+        else:
+            raw = self.get_plan_logs(run.plan_id)
+
+        clean = _ANSI_ESCAPE.sub("", raw)
+        error_lines = [
+            line.strip() for line in clean.splitlines() if line.lstrip().startswith("Error:")
+        ]
+        return "\n".join(error_lines) if error_lines else fallback
 
     def get_apply(self, apply_id: str) -> Apply:
         """Get apply details.

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -389,9 +389,8 @@ def run_errors(
                     date_str = (
                         run.created_at.strftime("%Y-%m-%d %H:%M") if run.created_at else "Unknown"
                     )
-                    console.print(
-                        f"  • [cyan]{run.id}[/cyan] ({date_str}): {run.message or 'No message'}"
-                    )
+                    error_text = client.runs.get_error_summary(run)
+                    console.print(f"  • [cyan]{run.id}[/cyan] ({date_str}): {error_text}")
 
         if not error_found:
             console.print(

--- a/src/terrapyne/models/run.py
+++ b/src/terrapyne/models/run.py
@@ -163,6 +163,9 @@ class Run(BaseModel):
     apply_id: str | None = None
     configuration_version_id: str | None = None
 
+    # Enrichment: plan stage status (extracted from plans included sideload)
+    plan_status: str | None = None
+
     # Enrichment: Commit info (extracted from configuration-version)
     commit_sha: str | None = Field(None, alias="commit-sha")
     commit_message: str | None = Field(None, alias="commit-message")
@@ -220,6 +223,7 @@ class Run(BaseModel):
         additions = attrs.get("resource-additions")
         changes = attrs.get("resource-changes")
         destructions = attrs.get("resource-destructions")
+        plan_status = None
 
         if included:
             for item in included:
@@ -235,9 +239,10 @@ class Run(BaseModel):
                         commit_message = ingress.get("commit-message")
                         commit_author = ingress.get("commit-author")
 
-                # Resource counts from plan (overrides run attributes if present)
+                # Plan status and resource counts from plans sideload
                 if item.get("type") == "plans" and item.get("id") == plan_id:
                     p_attrs = item.get("attributes", {})
+                    plan_status = p_attrs.get("status")
                     if p_attrs.get("resource-additions") is not None:
                         additions = p_attrs.get("resource-additions")
                     if p_attrs.get("resource-changes") is not None:
@@ -256,6 +261,7 @@ class Run(BaseModel):
             plan_id=plan_id,
             apply_id=apply_id,
             configuration_version_id=configuration_version_id,
+            plan_status=plan_status,
             commit_sha=commit_sha,
             commit_message=commit_message,
             commit_author=commit_author,

--- a/tests/features/run_error_summary.feature
+++ b/tests/features/run_error_summary.feature
@@ -1,0 +1,49 @@
+Feature: Run error summary extraction
+  As a DevOps engineer
+  I want to see the actual Terraform error message for an errored run
+  So I can diagnose failures without manually fetching logs
+
+  Background:
+    Given a RunsAPI instance with a mock client
+
+  Scenario: Plan-stage failure — error extracted from plan log
+    Given a run "run-plan-fail" is errored with plan status "errored"
+    And the plan log contains:
+      """
+      Error: creating EC2 Instance: OptInRequired: not subscribed to this service
+      """
+    When I get the error summary for the run
+    Then the summary contains "OptInRequired"
+    And only the plan log was fetched
+
+  Scenario: Apply-stage failure — plan succeeded, error extracted from apply log
+    Given a run "run-apply-fail" is errored with plan status "finished"
+    And the apply log contains:
+      """
+      Error: creating RDS DB Subnet Group (tec-db-default-defra): DBSubnetGroupAlreadyExists
+      """
+    When I get the error summary for the run
+    Then the summary contains "DBSubnetGroupAlreadyExists"
+    And only the apply log was fetched
+
+  Scenario: Multiple errors in apply log — all are returned
+    Given a run "run-multi-fail" is errored with plan status "finished"
+    And the apply log contains:
+      """
+      Error: creating RDS DB Subnet Group (tec-db-default-defra): DBSubnetGroupAlreadyExists
+      Error: creating RDS DB Subnet Group (tec-db-default-euw1): DBSubnetGroupAlreadyExists
+      """
+    When I get the error summary for the run
+    Then the summary contains "tec-db-default-defra"
+    And the summary contains "tec-db-default-euw1"
+
+  Scenario: No logs available — falls back to run message
+    Given a run "run-no-logs" is errored with plan status "errored"
+    And no plan log is available
+    When I get the error summary for the run
+    Then the summary contains the run message
+
+  Scenario: Run has no plan — returns run message
+    Given a run "run-no-plan" is errored with no plan ID
+    When I get the error summary for the run
+    Then the summary contains the run message

--- a/tests/test_api/test_run_error_summary.py
+++ b/tests/test_api/test_run_error_summary.py
@@ -1,0 +1,179 @@
+"""Tests for RunsAPI.get_error_summary — apply-log fallback when plan succeeds."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from terrapyne.api.runs import RunsAPI
+from terrapyne.models.run import Run
+
+
+def _make_run(
+    run_id: str,
+    plan_id: str | None = "plan-abc",
+    plan_status: str = "errored",
+    apply_id: str | None = "apply-abc",
+    message: str = "Triggered via CLI",
+) -> Run:
+    """Build a minimal errored Run for testing."""
+    data: dict = {
+        "id": run_id,
+        "type": "runs",
+        "attributes": {
+            "status": "errored",
+            "created-at": "2026-05-01T10:00:00Z",
+            "updated-at": "2026-05-01T10:05:00Z",
+            "message": message,
+            "auto-apply": True,
+            "is-destroy": False,
+        },
+        "relationships": {},
+    }
+    if plan_id:
+        data["relationships"]["plan"] = {"data": {"id": plan_id, "type": "plans"}}
+    if apply_id:
+        data["relationships"]["apply"] = {"data": {"id": apply_id, "type": "applies"}}
+
+    run = Run.from_api_response(data, included=[])
+    # Inject plan status via included sideload simulation
+    if plan_id:
+        run = Run.from_api_response(
+            data,
+            included=[
+                {
+                    "id": plan_id,
+                    "type": "plans",
+                    "attributes": {
+                        "status": plan_status,
+                        "log-read-url": None,
+                        "has-changes": True,
+                        "resource-additions": 0,
+                        "resource-changes": 0,
+                        "resource-destructions": 0,
+                        "resource-imports": 0,
+                        "action-invocations": 0,
+                    },
+                }
+            ],
+        )
+    return run
+
+
+class TestGetErrorSummary:
+    """RunsAPI.get_error_summary extracts the right log based on plan status."""
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def api(self, mock_client):
+        return RunsAPI(mock_client)
+
+    # ------------------------------------------------------------------
+    # Plan-stage failure
+    # ------------------------------------------------------------------
+
+    def test_plan_errored_fetches_plan_log(self, api, mock_client):
+        """When plan status is errored, the error comes from the plan log."""
+        run = _make_run("run-plan-fail", plan_status="errored")
+        mock_client._request.return_value.text = (
+            "Error: creating EC2 Instance: OptInRequired: not subscribed\n"
+        )
+
+        summary = api.get_error_summary(run)
+
+        assert "OptInRequired" in summary
+        # Only plan log fetched — apply log never called
+        called_paths = [c.args[1] for c in mock_client._request.call_args_list]
+        assert any("plans" in p and "logs" in p for p in called_paths)
+        assert not any("applies" in p for p in called_paths)
+
+    def test_plan_errored_strips_ansi(self, api, mock_client):
+        """ANSI escape codes in logs are stripped from the summary."""
+        run = _make_run("run-ansi", plan_status="errored")
+        mock_client._request.return_value.text = (
+            "\x1b[31mError: creating EC2 Instance: Forbidden\x1b[0m\n"
+        )
+
+        summary = api.get_error_summary(run)
+
+        assert "\x1b" not in summary
+        assert "Forbidden" in summary
+
+    # ------------------------------------------------------------------
+    # Apply-stage failure
+    # ------------------------------------------------------------------
+
+    def test_plan_finished_fetches_apply_log(self, api, mock_client):
+        """When plan status is finished, the error comes from the apply log."""
+        run = _make_run("run-apply-fail", plan_status="finished")
+        mock_client._request.return_value.text = (
+            "Error: creating RDS DB Subnet Group (tec-db-default-defra): "
+            "DBSubnetGroupAlreadyExists\n"
+        )
+
+        summary = api.get_error_summary(run)
+
+        assert "DBSubnetGroupAlreadyExists" in summary
+        # Only apply log fetched — plan log never called
+        called_paths = [c.args[1] for c in mock_client._request.call_args_list]
+        assert any("applies" in p and "logs" in p for p in called_paths)
+        assert not any("plans" in p and "logs" in p for p in called_paths)
+
+    def test_plan_finished_multiple_errors_all_returned(self, api, mock_client):
+        """All Error: lines from the apply log appear in the summary."""
+        run = _make_run("run-multi", plan_status="finished")
+        mock_client._request.return_value.text = (
+            "module.at_TakedaRDS.aws_db_subnet_group.dr_subnet_group[0]: Creating...\n"
+            "Error: creating RDS DB Subnet Group (tec-db-default-defra): DBSubnetGroupAlreadyExists\n"
+            "Error: creating RDS DB Subnet Group (tec-db-default-euw1): DBSubnetGroupAlreadyExists\n"
+        )
+
+        summary = api.get_error_summary(run)
+
+        assert "tec-db-default-defra" in summary
+        assert "tec-db-default-euw1" in summary
+
+    # ------------------------------------------------------------------
+    # Fallback cases
+    # ------------------------------------------------------------------
+
+    def test_no_plan_id_returns_run_message(self, api, mock_client):
+        """When the run has no plan relationship, fall back to run.message."""
+        run = _make_run("run-no-plan", plan_id=None, apply_id=None, message="Triggered via UI")
+
+        summary = api.get_error_summary(run)
+
+        assert summary == "Triggered via UI"
+        mock_client._request.assert_not_called()
+
+    def test_empty_plan_log_returns_run_message(self, api, mock_client):
+        """When the plan log is empty (e.g. 404), fall back to run.message."""
+        run = _make_run("run-no-logs", plan_status="errored", message="Triggered via CLI")
+        mock_client._request.return_value.text = ""
+
+        summary = api.get_error_summary(run)
+
+        assert summary == "Triggered via CLI"
+
+    def test_plan_log_no_error_lines_returns_run_message(self, api, mock_client):
+        """When plan log exists but has no Error: lines, fall back to run.message."""
+        run = _make_run("run-warn-only", plan_status="errored", message="Deploy failed")
+        mock_client._request.return_value.text = (
+            "Warning: Deprecated argument 'foo' in resource bar\n"
+            "Planning complete. Changes: 0 to add, 0 to change, 0 to destroy.\n"
+        )
+
+        summary = api.get_error_summary(run)
+
+        assert summary == "Deploy failed"
+
+    def test_empty_apply_log_falls_back_to_run_message(self, api, mock_client):
+        """When plan finished but apply log is empty, fall back to run.message."""
+        run = _make_run("run-empty-apply", plan_status="finished", message="Merge PR #42")
+        mock_client._request.return_value.text = ""
+
+        summary = api.get_error_summary(run)
+
+        assert summary == "Merge PR #42"


### PR DESCRIPTION
## Summary

- `tfc run errors` previously showed `run.message` (the git commit subject) for every errored run — making apply-stage failures like `DBSubnetGroupAlreadyExists` invisible without manually fetching logs
- Adds `RunsAPI.get_error_summary(run)`: when `run.plan_status == "finished"` (plan succeeded, apply failed), fetches the apply log; otherwise fetches the plan log; extracts `Error:` lines; falls back to `run.message`
- `Run.plan_status` is now populated from the `plans` included sideload in `from_api_response` — no extra API call needed
- ANSI escape codes are stripped from log output before extraction

## Test plan

- [ ] `tests/features/run_error_summary.feature` — 5 BDD scenarios covering plan-stage failure, apply-stage failure, multiple errors, empty log fallback, no-plan fallback
- [ ] `tests/test_api/test_run_error_summary.py` — 8 unit tests: all red before implementation, all green after
- [ ] Full suite: 667 passed, 81% coverage