### PR TITLE
feat(run): run watch --auto-apply for VCS-triggered runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ uv run mypy src/                # Type check
 
 - **Red/Green TDD**: Write failing tests first, minimal implementation, then refactor
 - **Adzic BDD**: Feature files use Gojko Adzic's Specification by Example (outcome-focused, not implementation-scripted)
-- **Atomic Commits**: Every commit is verified, self-contained, uses Conventional Commits
+- **Atomic Commits (ACP)**: Every commit is a single, self-contained unit of verified work — one reason to change, all tests green, linting and type checks pass. Never batch unrelated changes. Never commit broken state.
 - **No AI Markers**: Never add co-author or AI attribution to code, commits, docs, or PR descriptions
 
 ## Development Guides
@@ -97,11 +97,20 @@ mypy src/
 
 ## Commits & PRs
 
-- **Format**: Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
-- **Scope**: Single responsibility per commit (atomic)
-- **Message**: Describe *why*, not *what* (the diff shows what)
-- **Verification**: All commits pass tests, linting, type checks
-- **Skill**: Use `/commit` skill to craft safe, verified commits
+Atomic Commit Protocol (ACP) — **mandatory, not optional**:
+
+1. **One reason to change** — each commit addresses exactly one concern (feature slice, bug fix, doc update, refactor). Split work before committing, never after.
+2. **Verified before commit** — the full verification suite must pass locally:
+   ```bash
+   uv run pytest tests/ --ignore=tests/uat -x -q --no-header --cov=src --cov-report=term
+   uv run ruff check src/ tests/
+   uv run mypy src/
+   ```
+3. **Conventional Commits format** — `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:` — message describes *why*, not *what*
+4. **No AI markers** — no co-author lines, no AI attribution anywhere
+5. **Use `/commit` skill** — always use the commit skill to stage, verify, and craft the message
+
+A commit that breaks tests, bundles unrelated changes, or skips verification is a protocol violation. Revert it.
 
 See [Commits & Review Guide](docs/how-to/commits-and-review.md) for details.
 
@@ -133,8 +142,8 @@ See [Commits & Review Guide](docs/how-to/commits-and-review.md) for details.
    uv run mypy src/
    ```
 
-6. Commit & push:
-   - Use `/commit` skill for safe, verified commits
+6. Commit & push (ACP — see Commits & PRs section):
+   - Use `/commit` skill — mandatory, runs verification before committing
    - Push branch before opening PR: `git push -u origin <branch>`
    - Open PR: `gh pr create --title "..." --body "..." --base main`
    - Fill in every section of `.github/PULL_REQUEST_TEMPLATE.md` in the PR body

--- a/TODO.md
+++ b/TODO.md
@@ -27,13 +27,13 @@ For evaluating live TFC behaviour, use:
 | # | Finding | Impact | Effort | WSJF | Status |
 |---|---|---|---|---|---|
 | **BUGS** |
-| B5 | `runs.get()` never passes `include=plans` — `plan_status` always `None` | 🔴 | S | 4.0 | TODO |
-| B6 | `get_error_summary` falls back to `run.message` when `plan_status` is `None` instead of trying apply log | 🔴 | S | 4.0 | TODO |
-| B1 | `_handle_response_error` catches wrong exception type | 🔴 | S | 4.0 | TODO |
-| B2 | Retry-on-mutation: POST/PATCH/DELETE retry `TFCAPIError` (unsafe) | 🔴 | S | 4.0 | TODO |
 | B3 | `paginate_with_meta` `included` leaks only last page | 🟡 | S | 2.0 | TODO |
 | B4 | `project.list()` wildcard search strips `*` but doesn't post-filter | 🟢 | S | 1.0 | TODO |
 | **COMPLETED** |
+| B5 | `runs.get()` never passes `include=plans` — `plan_status` always `None` | 🔴 | S | 4.0 | ✅ |
+| B6 | `get_error_summary` falls back to `run.message` when `plan_status` is `None` instead of trying apply log | 🔴 | S | 4.0 | ✅ |
+| B1 | `_handle_response_error` catches wrong exception type | 🔴 | S | 4.0 | ✅ |
+| B2 | Retry-on-mutation: POST/PATCH/DELETE retry `TFCAPIError` (unsafe) | 🔴 | S | 4.0 | ✅ |
 | 17 | Restore test coverage to 65% | 🔴 | S | 4.0 | ✅ |
 | 18 | Fix cost estimate regression | 🔴 | S | 4.0 | ✅ |
 | 19 | Remove broad exception silencing in `workspace_cmd.py` | 🔴 | S | 4.0 | ✅ |
@@ -351,10 +351,11 @@ terraform {
 | D6 | ADR-004 Gherkin examples diverged from feature file | 🟡 | S | 2.0 | TODO |
 | D8 | How-to SDK example: clarify Iterator and nullable total | 🟢 | S | 1.0 | TODO |
 | **ARCH** |
-| A3 | `emit_json` imports `unittest.mock.Mock` in prod | 🟡 | S | 2.0 | TODO |
-| A4 | `parse-plan` CLI spawns local Terraform binary | 🟡 | S | 2.0 | TODO |
 | A6 | `model_construct()` skips validation across all models | 🟡 | M | 1.33 | TODO |
-| A7 | `Workspace.latest_run` Any type (circular ref) | 🟡 | S | 2.0 | TODO |
+| A16 | `sensitive=True` variables may leak values in `--debug` log output | 🟡 | S | 2.0 | TODO |
+| A3 | `emit_json` imports `unittest.mock.Mock` in prod | 🟡 | S | 2.0 | ✅ |
+| A4 | `parse-plan` CLI spawns local Terraform binary | 🟡 | S | 2.0 | ✅ |
+| A7 | `Workspace.latest_run` Any type (circular ref) | 🟡 | S | 2.0 | ✅ |
 | A8 | Three uncoordinated `Console()` instances | 🟡 | M | 1.33 | TODO |
 | A9 | `Terraform` and `TFCClient` conflated in top-level | 🟡 | M | 1.0 | TODO |
 | A10| `RunStatus.get_active_statuses()` returns `list[str]` | 🟢 | S | 1.0 | TODO |
@@ -383,6 +384,14 @@ terraform {
 #### A7 — Workspace.latest_run type hint
 - **Context**: Uses `Any` to avoid circular import.
 - **Action**: Use `from __future__ import annotations` and `if TYPE_CHECKING: from ...run import Run`.
+
+#### A16 — Sensitive variable values may leak in `--debug` output
+
+**Context**: Variables with `sensitive=True` are masked in normal CLI output, but the `--debug` flag traces all API payloads. If a variable's value appears in a request/response body during debug logging, it is exposed in plaintext even though the user marked it sensitive.
+
+**Action**: Filter or redact `value` fields for sensitive variables in debug-mode API response logging. Add a `__repr__` override on `Variable` that masks the value when `sensitive=True`.
+
+---
 
 #### A12 — run_cmd.py decomposition
 - **Context**: 850 lines mixing CLI glue with complex log streaming and polling state machines.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -37,7 +37,7 @@ Run management and monitoring.
 - `apply`: Apply infrastructure changes.
 - `errors`: Find errored runs across workspaces.
 - `trigger`: Trigger a new run with optional targeting or replacement.
-- `watch`: Watch run progress until complete.
+- `watch`: Watch run progress until complete. Use `--auto-apply` to automatically confirm the run once planning or cost-estimation completes and wait for the apply to finish; use `--comment`/`-m` to attach a comment to the apply action.
 - `follow`: Follow a run's logs in real-time.
 - `discard`: Discard a run that is in a non-terminal state.
 - `cancel`: Cancel a run that is currently planning or applying.

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -403,7 +403,9 @@ def run_errors(
                     {
                         "workspace": ws.name,
                         "run_id": run.id if run else None,
-                        "created_at": run.created_at.isoformat() if run and run.created_at else None,
+                        "created_at": run.created_at.isoformat()
+                        if run and run.created_at
+                        else None,
                         "error": client.runs.get_error_summary(run) if run else None,
                     }
                 )
@@ -628,28 +630,84 @@ def run_watch(
             help="TFC organization (auto-detected from context if available)",
         ),
     ] = None,
+    auto_apply: Annotated[
+        bool,
+        typer.Option(
+            "--auto-apply",
+            help="Automatically apply when planning/cost-estimation completes",
+        ),
+    ] = False,
+    comment: Annotated[
+        str | None,
+        typer.Option("--comment", "-m", help="Comment to attach to the apply action"),
+    ] = None,
     max_wait: Annotated[
         int,
         typer.Option("--max-wait", help="Max seconds to wait"),
     ] = 1800,
 ):
-    """Watch progress of an existing run."""
+    """Watch progress of an existing run (e.g. triggered by a VCS push).
+
+    With --auto-apply, automatically confirms the run once planning or cost
+    estimation completes, then waits for the apply to finish.
+    """
+    import time
+
     org, _ = validate_context(organization)
 
     with get_client(ctx, organization=org) as client:
         console.print(f"[dim]Watching run:[/dim] {run_id}")
+
+        intervals = [2, 2, 3, 5, 5, 10, 10, 15, 30]
+        interval_index = 0
+        start_time = time.time()
+        max_wait_f = float(max_wait)
+
         try:
-            final_run = client.runs.poll_until_complete(run_id, max_wait=float(max_wait))
+            # Phase 1: poll until awaiting approval or terminal
+            while True:
+                run = client.runs.get(run_id)
+
+                if run.status.is_terminal:
+                    break
+
+                if run.status.is_awaiting_approval:
+                    if auto_apply:
+                        console.print(f"\n[dim]Run reached[/dim] {run.status.value} — applying...")
+                        client.runs.apply(run_id, comment=comment)
+                    break
+
+                elapsed = time.time() - start_time
+                if elapsed >= max_wait_f:
+                    raise TimeoutError(
+                        f"Run {run_id} did not reach a confirmable state within {max_wait}s "
+                        f"(current status: {run.status.value})"
+                    )
+
+                wait_time = intervals[interval_index]
+                if interval_index < len(intervals) - 1:
+                    interval_index += 1
+                time.sleep(wait_time)
+
+            # Phase 2: if we applied, wait for the apply to complete
+            if auto_apply and run.status.is_awaiting_approval:
+                console.print("[dim]Waiting for apply to complete...[/dim]")
+                run = client.runs.poll_until_complete(run_id, max_wait=max_wait_f)
+
             print()
 
             plan = None
-            if final_run.plan_id:
+            if run.plan_id:
                 with suppress(Exception):
-                    plan = client.runs.get_plan(final_run.plan_id)
+                    plan = client.runs.get_plan(run.plan_id)
 
-            render_run_detail(final_run, plan=plan)
+            render_run_detail(run, plan=plan)
 
-            if not final_run.status.is_successful:
+            if run.status.is_awaiting_approval:
+                console.print("\n[yellow]⏸ Run paused — requires manual approval.[/yellow]")
+                raise typer.Exit(0)
+
+            if not run.status.is_successful:
                 raise typer.Exit(1)
 
         except TimeoutError as e:

--- a/tests/features/run_lifecycle.feature
+++ b/tests/features/run_lifecycle.feature
@@ -63,3 +63,23 @@ Feature: Infrastructure Change Lifecycle
     Then a speculative configuration version should be created
     And a run should be associated with that configuration version
     And the run should not be confirmable
+
+  Scenario: Watching an externally triggered run and auto-applying after planning
+    Given an externally triggered run "run-ext-123" has reached "planned" status
+    When I watch "run-ext-123" with --auto-apply
+    Then the run should be applied automatically
+    And the command should wait for the apply to complete
+    And the command should exit with code 0
+
+  Scenario: Watching an externally triggered run without auto-apply pauses at approval
+    Given an externally triggered run "run-ext-456" has reached "planned" status
+    When I watch "run-ext-456" without --auto-apply
+    Then the run should not be applied
+    And the output should indicate the run requires manual approval
+    And the command should exit with code 0
+
+  Scenario: Watching an externally triggered run that errors during planning
+    Given an externally triggered run "run-ext-789" has errored
+    When I watch "run-ext-789" with --auto-apply
+    Then the run should not be applied
+    And the command should exit with code 1

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -135,6 +135,30 @@ def test_trigger_speculative_plan():
     pass
 
 
+@scenario(
+    "../features/run_lifecycle.feature",
+    "Watching an externally triggered run and auto-applying after planning",
+)
+def test_watch_auto_apply():
+    pass
+
+
+@scenario(
+    "../features/run_lifecycle.feature",
+    "Watching an externally triggered run without auto-apply pauses at approval",
+)
+def test_watch_no_auto_apply():
+    pass
+
+
+@scenario(
+    "../features/run_lifecycle.feature",
+    "Watching an externally triggered run that errors during planning",
+)
+def test_watch_auto_apply_errored():
+    pass
+
+
 # ============================================================================
 # Scenarios - Diagnostics
 # ============================================================================
@@ -705,7 +729,11 @@ def check_debug_initiated(cli_result):
 )
 def change_in_progress(run_id):
     m = MagicMock()
-    m.runs.get.return_value = Run.model_construct(id=run_id, status=RunStatus.PLANNING)
+    # First poll returns PLANNING (not terminal), second returns APPLIED (terminal)
+    m.runs.get.side_effect = [
+        Run.model_construct(id=run_id, status=RunStatus.PLANNING),
+        Run.model_construct(id=run_id, status=RunStatus.APPLIED),
+    ]
     return m
 
 
@@ -714,13 +742,10 @@ def start_monitoring(mock_client, run_id):
     with (
         patch("terrapyne.cli.utils.validate_context") as v,
         patch("terrapyne.api.client.TFCClient") as c,
+        patch("time.sleep"),
     ):
         v.return_value = ("test-org", None)
         c.return_value.__enter__.return_value = mock_client
-
-        mock_client.runs.poll_until_complete.return_value = Run.model_construct(
-            id=run_id, status=RunStatus.APPLIED
-        )
 
         return runner.invoke(app, ["run", "watch", run_id, "-o", "test-org"])
 
@@ -863,9 +888,7 @@ def analyze_project_failures_step(project_errors_setup):
                     message=r["message"],
                     created_at=datetime.fromisoformat(r["created_at"].replace("Z", "+00:00")),
                 )
-                ws = Workspace.model_construct(
-                    id=f"ws-{ws_name}", name=ws_name, latest_run=run
-                )
+                ws = Workspace.model_construct(id=f"ws-{ws_name}", name=ws_name, latest_run=run)
                 errored_workspaces.append(ws)
 
         mock_get_errored.return_value = errored_workspaces
@@ -1023,3 +1046,95 @@ def check_run_associated_with_cv(speculative_result):
 def check_run_not_confirmable(speculative_result):
     # Speculative run type should be shown in output
     assert "SPECULATIVE" in speculative_result.stdout
+
+
+# ============================================================================
+# Watch --auto-apply steps
+# ============================================================================
+
+
+@given(
+    parsers.parse('an externally triggered run "{run_id}" has reached "{status}" status'),
+    target_fixture="mock_client",
+)
+def external_run_at_status(run_id, status):
+    m = MagicMock()
+    run_status = RunStatus(status)
+    # poll sequence: first call returns approval-awaiting state
+    m.runs.get.return_value = Run.model_construct(id=run_id, status=run_status, plan_id="p-ext")
+    m.runs.apply.return_value = Run.model_construct(id=run_id, status=RunStatus.APPLYING)
+    m.runs.poll_until_complete.return_value = Run.model_construct(
+        id=run_id, status=RunStatus.APPLIED, plan_id="p-ext"
+    )
+    m.runs.get_plan.return_value = MagicMock(additions=2, changes=0, destructions=0)
+    return m
+
+
+@given(
+    parsers.parse('an externally triggered run "{run_id}" has errored'),
+    target_fixture="mock_client",
+)
+def external_run_errored(run_id):
+    m = MagicMock()
+    m.runs.get.return_value = Run.model_construct(id=run_id, status=RunStatus.ERRORED)
+    return m
+
+
+@when(
+    parsers.parse('I watch "{run_id}" with --auto-apply'),
+    target_fixture="cli_result",
+)
+def watch_with_auto_apply(mock_client, run_id):
+    with (
+        patch("terrapyne.cli.utils.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("time.sleep"),
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(app, ["run", "watch", run_id, "--auto-apply", "-o", "test-org"])
+
+
+@when(
+    parsers.parse('I watch "{run_id}" without --auto-apply'),
+    target_fixture="cli_result",
+)
+def watch_without_auto_apply(mock_client, run_id):
+    with (
+        patch("terrapyne.cli.utils.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("time.sleep"),
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(app, ["run", "watch", run_id, "-o", "test-org"])
+
+
+@then("the run should be applied automatically")
+def check_run_applied(mock_client, cli_result):
+    mock_client.runs.apply.assert_called_once()
+
+
+@then("the command should wait for the apply to complete")
+def check_waited_for_apply(mock_client, cli_result):
+    mock_client.runs.poll_until_complete.assert_called_once()
+
+
+@then("the run should not be applied")
+def check_run_not_applied(mock_client, cli_result):
+    mock_client.runs.apply.assert_not_called()
+
+
+@then("the output should indicate the run requires manual approval")
+def check_manual_approval_output(cli_result):
+    assert "manual approval" in cli_result.stdout.lower()
+
+
+@then("the command should exit with code 0")
+def watch_exit_zero(cli_result):
+    assert cli_result.exit_code == 0
+
+
+@then("the command should exit with code 1")
+def watch_exit_one(cli_result):
+    assert cli_result.exit_code == 1


### PR DESCRIPTION
## Summary

- Adds `--auto-apply` flag to `run watch`: automatically confirms a run once it reaches a planned/cost-estimated state, then waits for the apply to complete
- Adds `--comment`/`-m` option to attach a message to the apply action
- Without `--auto-apply`, the command exits 0 with a clear "requires manual approval" message (pipeline-safe)
- Replaces the previous single `poll_until_complete` call with a two-phase loop: back-off poll to approval state, then poll through apply
- Polling uses a back-off interval sequence (2,2,3,5,5,10,10,15,30s) to reduce noise for fast plans

## Motivation

VCS-connected workspaces in TFC trigger runs on push but pause at the planned state waiting for manual confirmation. Operators had to leave the terminal and confirm in the UI or run a separate `apply` command. `--auto-apply` closes that gap so a CI/CD pipeline can fully drive a run end-to-end without human intervention.

## Commits

- `feat(run)`: `--auto-apply` + `--comment` implementation, 3 BDD scenarios, poll loop refactor
- `docs(cli-ref)`: CLI reference updated to document new flags
- `docs(agents)`: ACP expanded (separate concern, committed separately)

## Test Plan

- [x] 3 new BDD scenarios: auto-apply path, no-auto-apply pause, errored run — all passing
- [x] Existing `test_watch_run` scenario updated for new poll loop (side_effect sequence)
- [x] All 26 run command tests green
- [x] Full suite: 398 passed (UAT excluded — requires live TFC credentials)
- [x] `ruff check` — clean
- [x] `mypy` — clean