### PR TITLE
feat(sdk): export missing models and align documentation (Batch 1)

### DIFF
--- a/docs/explanation/architecture/ADR-004-workspace-dashboard-testing.md
+++ b/docs/explanation/architecture/ADR-004-workspace-dashboard-testing.md
@@ -15,23 +15,24 @@ The workspace-dashboard feature requires writing BDD tests that verify the dashb
 ### Feature specification (Gherkin)
 
 ```gherkin
-Feature: Workspace Activity Snapshot
+Feature: Workspace Activity Dashboard
   As a DevOps engineer
-  I want a health and activity summary when I inspect a workspace
-  So that I can assess its state without opening the GUI
+  I want to see a health and activity summary when I inspect a workspace
+  So that I can assess its state and recent activity without opening the GUI
 
   Scenario: Workspace with recent successful run shows healthy status
-    Given a workspace with a recently applied run linked to a VCS repository
-    When I show the workspace
-    Then I should see the workspace health status
-    And I should see the count of queued runs
-    And I should see the latest commit information
+    Given a workspace with a recently applied run
+    When I show the workspace details
+    Then I should see the workspace health snapshot
+    And I should see the latest run information
+    And I should see the active run count
 
   Scenario: Workspace with no run history shows unknown health
-    Given a workspace with no run history
-    When I show the workspace
-    Then I should see that health status is unknown
-    And I should see active run count as zero
+    Given a workspace with no runs
+    When I show the workspace details
+    Then I should see the workspace health snapshot
+    And I should see unknown health status
+    And I should see zero active runs
 ```
 
 ### Step definitions (Python)

--- a/docs/explanation/plan-parser.md
+++ b/docs/explanation/plan-parser.md
@@ -1,37 +1,49 @@
-# Plan Parser
+# Plan Parser Analysis
 
-## What it is
+The `PlanParser` is a conceptual component of Terrapyne designed to bridge the gap between unstructured terminal output and structured program execution. It extracts machine-readable states from raw CLI plan logs.
 
-The plan parser extracts structured data from Terraform plain-text plan output. It returns a dictionary describing resource changes, a plan summary (add/change/destroy counts), and any diagnostic errors.
+## Conceptual Background
 
-## Why it exists
+When Terraform runs in a remote-execution environment like Terraform Cloud (TFC) or Terraform Enterprise (TFE), it streams its execution output as plain-text terminal logs. Because TFC streams this standard output to developers and CI pipelines, the output is optimized for human readability rather than automated ingestion:
+1. It contains ANSI escape codes for styling and colors.
+2. It uses visual indentation (spacing, `+`, `-`, `~`) to denote actions.
+3. It does not provide a native machine-readable API payload (like JSON plan files) during execution stream follow.
 
-Terraform Cloud's remote backend does not support `terraform plan -json` or `terraform plan -out=`. The only machine-readable option is capturing the plain-text output of `terraform plan` and parsing it. The plan parser solves this by implementing a state-machine that strips ANSI codes and identifies resource blocks, attributes, and plan summaries from that output.
+To automate policies or inspect changes programmatically before apply, Terrapyne must parse this unstructured raw log.
 
-## When to use it
+## Why a State Machine?
 
-Use the plan parser when:
-- You are running Terraform against a TFC remote backend and need structured change data before creating a run.
-- You want to count or classify resource changes (creates, destroys, imports) from a captured plan log.
-- You are building a pre-apply validation step that does not have access to a JSON plan file.
+A simple line-by-line regex match is insufficient to parse Terraform plan logs because the context of a line depends on the lines preceding it. For example, a line containing an attribute change (`+ name = "my-db"`) only makes sense if we know which resource block it belongs to.
 
-Do not use it for local Terraform workflows where `terraform plan -json` is available — use the JSON output instead.
+To resolve this, the plan parser is implemented as a **deterministic state machine** with the following logical states:
 
-## Usage
-
-```python
-from terrapyne import PlanParser
-
-parser = PlanParser()
-result = parser.parse(plan_text)
-
-print(f"Status: {result['status']}")
-for resource in result.get("resources", []):
-    print(f"  {resource['address']}: {resource['change']['actions']}")
+```mermaid
+stateDiagram-v2
+    [*] --> SCANNING
+    SCANNING --> IN_RESOURCE_BLOCK : Match resource header (e.g., "  # aws_instance.web will be created")
+    IN_RESOURCE_BLOCK --> IN_RESOURCE_BLOCK : Read attributes or nested blocks
+    IN_RESOURCE_BLOCK --> SCANNING : Blank line or end of block
+    SCANNING --> SUMMARY : Match "Plan: X to add, Y to change, Z to destroy"
+    SUMMARY --> [*]
 ```
 
-`result` contains:
-- `status` — overall plan status (`planned`, `no_changes`, `errored`)
-- `resources` — list of resource change objects with `address`, `type`, `name`, and `change`
-- `plan_summary` — `{"add": N, "change": N, "destroy": N, "import": N}`
-- `diagnostics` — list of Terraform error/warning messages
+### State Transitions & Mechanics
+
+1. **`SCANNING`**: The default state. The parser discards general terminal logs, VCS information, and CLI warnings, searching for a resource change marker (e.g., lines starting with `  #` or `#`).
+2. **`IN_RESOURCE_BLOCK`**: Once a resource header is matched (such as `# null_resource.test will be created`), the parser transitions here. It tracks the current resource name, type, and path. Subsequent lines are parsed to extract attribute changes until a blank line or a new block header transitions it out.
+3. **`SUMMARY`**: The parser searches for the final "Plan:" or "No changes." summary line to determine the global action counts.
+
+## Parsing Challenges & Design Decisions
+
+### 1. ANSI Color Code Stripping
+Terraform streams styled output containing ANSI Escape Sequences (e.g., `\u001b[0m`). These sequences fragment strings and break standard regular expressions.
+- *Decision*: The parser applies a preprocessing regex filter to sanitize the text stream, stripping all styling escape codes before feeding lines to the state machine.
+
+### 2. Provider-Specific Diff Formats
+Different Terraform providers and resource schemas can produce nested structures, map lookups, or block lists in the diff.
+- *Decision*: Rather than attempting full schema validation, the parser focuses on extracting the action (`create`, `update`, `destroy`, `read`, `noop`) and the resource coordinates (type, name, provider, module path) by matching known line patterns.
+
+### 3. Human-Readable Summaries vs. Rigid Patterns
+The exact phrasing of the summary line changes across major Terraform versions (e.g., introducing "import" counts in newer versions).
+- *Decision*: The parser uses flexible regular expressions that look for combinations of action verbs (add, change, destroy, import) alongside digits, fallback-matching if certain counts are absent.
+

--- a/docs/reference/sdk.md
+++ b/docs/reference/sdk.md
@@ -47,20 +47,54 @@ All API operations are accessed through `TFCClient` properties:
 | `client.state_versions` | `StateVersionsAPI` | list, get, get_current, download, list_outputs, find_version_before |
 | `client.vcs` | `VCSAPI` | get_workspace_vcs, update_workspace_branch, list_connections, list_repositories |
 
-## Models
+## Pydantic Models
 
-All API responses are parsed into Pydantic models:
+All API responses are parsed into type-safe Pydantic models. You can import them directly from the package root:
 
 ```python
-from terrapyne.models import (
-    Apply, Plan, Project, Run, RunStatus,
-    StateVersion, StateVersionOutput,
-    Team, TeamProjectAccess,
-    VCSConnection, Workspace, WorkspaceVCS, WorkspaceVariable,
+from terrapyne import (
+    Apply,
+    Plan,
+    Project,
+    Run,
+    RunStatus,
+    RunTrigger,
+    StateVersion,
+    StateVersionOutput,
+    Team,
+    TeamProjectAccess,
+    VariableSet,
+    VariableSetVariable,
+    VCSConnection,
+    Workspace,
+    WorkspaceVCS,
+    WorkspaceVariable,
 )
 ```
 
-Each model has a `from_api_response(data)` class method for parsing raw API dicts.
+Each model has a `from_api_response(data)` class method for parsing raw API responses.
+
+### Models Reference
+
+| Model | Description | Key Attributes |
+|---|---|---|
+| `Workspace` | Represents a Terraform Cloud workspace. | `id`, `name`, `terraform_version`, `working_directory`, `execution_mode` |
+| `WorkspaceVCS` | VCS repository settings linked to a workspace. | `identifier`, `branch`, `oauth_token_id` |
+| `WorkspaceVariable` | A variable defined in a workspace (Terraform or Environment). | `id`, `key`, `value`, `category`, `sensitive`, `hcl` |
+| `VariableSet` | A reusable group of variables scoped to an organization or projects. | `id`, `name`, `description`, `global`, `project_count`, `var_count` |
+| `VariableSetVariable` | A single variable defined inside a Variable Set. | `id`, `key`, `value`, `category`, `sensitive`, `hcl` |
+| `Run` | Represents a Terraform execution run. | `id`, `status`, `message`, `is_speculative`, `created_at`, `plan_status` |
+| `RunStatus` | Enum of possible run states (e.g., `PLANNING`, `APPLIED`, `ERRORED`). | Enum values representing the API state machine. |
+| `RunTrigger` | Source workspace trigger that initiates runs on target workspaces. | `id`, `workspace_id`, `source_workspace_id` |
+| `Plan` | Details of a run's planning phase. | `id`, `status`, `resource_additions`, `resource_destructions` |
+| `Apply` | Details of a run's apply phase. | `id`, `status`, `resource_additions`, `resource_destructions` |
+| `StateVersion` | Represents a specific state file version. | `id`, `serial`, `created_at`, `resource_count`, `run_id` |
+| `StateVersionOutput` | Represents a single output from a state version. | `name`, `value`, `type`, `sensitive` |
+| `Team` | Represents an organization team. | `id`, `name`, `member_count` |
+| `TeamProjectAccess` | Represents a team's permissions on a project. | `team_id`, `project_id`, `access` |
+| `Project` | Represents a project grouping workspaces. | `id`, `name`, `description` |
+| `VCSConnection` | An OAuth connection link to a VCS provider (e.g., GitHub, GitLab). | `id`, `service_provider`, `name` |
+
 
 ## Examples
 

--- a/src/terrapyne/__init__.py
+++ b/src/terrapyne/__init__.py
@@ -35,12 +35,16 @@ from .core.exceptions import (
     WorkspaceNotFoundError,
 )
 from .core.plan_parser import TerraformPlainTextPlanParser as PlanParser
+from .models.apply import Apply
 from .models.plan import Plan
 from .models.project import Project
-from .models.run import Run
+from .models.run import Run, RunStatus
+from .models.run_trigger import RunTrigger
+from .models.state_version import StateVersion, StateVersionOutput
 from .models.team import Team
 from .models.team_access import TeamProjectAccess
 from .models.variable import WorkspaceVariable
+from .models.varset import VariableSet, VariableSetVariable
 from .models.vcs import VCSConnection
 from .models.workspace import Workspace, WorkspaceVCS
 
@@ -68,6 +72,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "VCSAPI",
+    "Apply",
     "CloneWorkspaceAPI",
     "Plan",
     "PlanParser",
@@ -75,7 +80,11 @@ __all__ = [
     "ProjectAPI",
     "RemoteBackend",
     "Run",
+    "RunStatus",
+    "RunTrigger",
     "RunsAPI",
+    "StateVersion",
+    "StateVersionOutput",
     "TFCAPIError",
     "TFCAuthenticationError",
     "TFCClient",
@@ -93,6 +102,8 @@ __all__ = [
     "TerrapyneError",
     "VCSConnection",
     "VCSTokenRequiredError",
+    "VariableSet",
+    "VariableSetVariable",
     "Workspace",
     "WorkspaceAPI",
     "WorkspaceAlreadyExistsError",

--- a/tests/unit/test_sdk_and_utils.py
+++ b/tests/unit/test_sdk_and_utils.py
@@ -147,13 +147,37 @@ class TestEmitJson:
 
 class TestSDKNamespace:
     def test_sdk_imports(self):
-        from terrapyne import RunsAPI, TFCClient
+        from terrapyne import (
+            Apply,
+            RunsAPI,
+            RunStatus,
+            RunTrigger,
+            StateVersion,
+            StateVersionOutput,
+            TFCClient,
+            VariableSet,
+            VariableSetVariable,
+        )
 
         assert TFCClient is not None
         assert RunsAPI is not None
+        assert VariableSet is not None
+        assert RunTrigger is not None
+        assert Apply is not None
+        assert StateVersion is not None
+        assert StateVersionOutput is not None
+        assert RunStatus is not None
+        assert VariableSetVariable is not None
 
     def test_main_all_exports(self):
         import terrapyne
 
         assert "TFCClient" in terrapyne.__all__
         assert "Plan" in terrapyne.__all__
+        assert "VariableSet" in terrapyne.__all__
+        assert "RunTrigger" in terrapyne.__all__
+        assert "Apply" in terrapyne.__all__
+        assert "StateVersion" in terrapyne.__all__
+        assert "StateVersionOutput" in terrapyne.__all__
+        assert "RunStatus" in terrapyne.__all__
+        assert "VariableSetVariable" in terrapyne.__all__


### PR DESCRIPTION
## Summary

Exports missing models directly from the `terrapyne` root namespace and completely aligns SDK and architecture documentation.

closes #105

---

## Why

**Driver:**
Missing top-level exports for commonly used Pydantic models (like `VariableSet`, `RunTrigger`, etc.) forced users to import from deep nested module paths (`terrapyne.models...`), violating the intended simple API surface. Additionally, SDK documentation was incomplete, the `plan-parser.md` was formatted as a guide rather than an explanation, and the ADR-004 Gherkin scenarios were drifting from the actual feature implementation. 

**Alternatives rejected:**
- *Deprecating direct model imports:* Rejected because Pydantic models are a core part of the SDK payload that users need to construct typed variables or parse outputs.
- *Keeping `plan-parser.md` as reference:* Rejected because Diataxis requires strict separation between "how-to/reference" and "conceptual explanation." The mechanics of the internal ANSI stripping state machine require a conceptual explanation.

---

## What changed

**Affected:** `src/terrapyne/__init__.py` · `docs/reference/sdk.md` · `docs/explanation/plan-parser.md` · `docs/explanation/architecture/ADR-004-workspace-dashboard-testing.md` · `tests/unit/test_sdk_and_utils.py`

---

## Risk and review focus

**Look here first:** 
`src/terrapyne/__init__.py` to ensure all desired models are exported. Note the `__all__` list is intentionally formatted by `ruff` using its case-sensitive `isort` alphabetical logic.

**Edge cases left for later:**
None.

**Skip:** 
The ADR-004 markdown changes; they just directly copy the scenarios from `workspace_dashboard.feature`.

---

## Testing

**Scenarios tested:**
- `test_sdk_and_utils.py` validates new root-level exports.
- `ruff check .` validates `__all__` list is compliant.

**Coverage delta:** 82.63% (No functional logic modified)

---

<details>
<summary>Pre-submission checklist</summary>

**Process**
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Commits are atomic — code + tests together in each
- [x] [TODO.md](TODO.md) updated if this adds new backlog items

</details>
