### PR TITLE
feat(cli): add auto-apply flag to run follow command

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -34,13 +34,12 @@ Run management and monitoring.
 - `show`: Show detailed information for a specific run.
 - `plan`: Create a new plan (run) for a workspace.
 - `logs`: Fetch and print the logs for a specific run.
-- `apply`: Apply infrastructure changes.
+- `apply`: Apply a plan or trigger a new auto-apply run.
 - `errors`: Find errored runs across workspaces.
-- `trigger`: Trigger a new run with optional targeting or replacement.
+- `trigger`: Trigger a new run with advanced queue management. Use `--auto-apply` to apply if plan succeeds. Use `--speculative` for read-only plans.
 - `watch`: Watch run progress until complete. Use `--auto-apply` to automatically confirm the run once planning or cost-estimation completes and wait for the apply to finish; use `--comment`/`-m` to attach a comment to the apply action.
-- `follow`: Follow a run's logs in real-time.
+- `follow`: Follow a run's logs in real-time. Use `--auto-apply` to automatically apply when planning/cost-estimation completes.
 - `discard`: Discard a run that is in a non-terminal state.
-- `cancel`: Cancel a run that is currently planning or applying.
 - `parse-plan`: Parse plain text terraform plan output.
 
 ---

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -291,7 +291,11 @@ def run_apply(
         typer.Option("--wait/--no-wait", help="Wait for completion"),
     ] = True,
 ):
-    """Apply a plan or trigger a new auto-apply run."""
+    """Apply a plan or trigger a new auto-apply run.
+
+    If a RUN_ID is provided, applies that existing run.
+    If omitted, triggers a completely new run on the workspace with auto-apply enabled.
+    """
     org, ws_context_name = validate_context(organization, workspace)
 
     with get_client(ctx, organization=org) as client:
@@ -508,7 +512,14 @@ def run_trigger(
         ),
     ] = False,
 ):
-    """Trigger a new run with advanced queue management."""
+    """Trigger a new run with advanced queue management.
+
+    Supports advanced behaviors:
+    * `--auto-apply`: Automatically apply if the plan succeeds.
+    * `--speculative`: Create a true speculative plan (read-only, cannot be applied).
+    * `--wait-queue`: Wait for active runs to finish before triggering.
+    * `--discard-older`: Discard any active runs before triggering.
+    """
     # Resolve organization and workspace
     org, workspace_name = validate_context(organization, workspace, require_workspace=True)
 

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -728,12 +728,27 @@ def run_follow(
             help="TFC organization (auto-detected from context if available)",
         ),
     ] = None,
+    auto_apply: Annotated[
+        bool,
+        typer.Option(
+            "--auto-apply",
+            help="Automatically apply when planning/cost-estimation completes",
+        ),
+    ] = False,
+    comment: Annotated[
+        str | None,
+        typer.Option("--comment", "-m", help="Comment to attach to the apply action"),
+    ] = None,
     max_wait: Annotated[
         int,
         typer.Option("--max-wait", help="Max seconds to wait"),
     ] = 1800,
 ):
-    """Stream logs of an existing run in real-time."""
+    """Stream logs of an existing run in real-time.
+
+    With --auto-apply, automatically confirms the run once planning or cost
+    estimation completes, then waits for the apply to finish.
+    """
     org, _ = validate_context(organization)
 
     with get_client(ctx, organization=org) as client:
@@ -775,6 +790,11 @@ def run_follow(
                     console.print(
                         f"\n[red]Run failed before generating logs: {run.status.value}[/red]"
                     )
+
+            # Auto-apply logic
+            if auto_apply and run.status.is_awaiting_approval:
+                console.print(f"\n[dim]Run reached[/dim] {run.status.value} — applying...")
+                client.runs.apply(run_id, comment=comment)
 
         try:
             final_run = client.runs.poll_until_complete(

--- a/tests/features/run_lifecycle.feature
+++ b/tests/features/run_lifecycle.feature
@@ -83,3 +83,10 @@ Feature: Infrastructure Change Lifecycle
     When I watch "run-ext-789" with --auto-apply
     Then the run should not be applied
     And the command should exit with code 1
+
+  Scenario: Following an externally triggered run and auto-applying after planning
+    Given an externally triggered run "run-ext-999" has reached "planned" status
+    When I follow "run-ext-999" with --auto-apply
+    Then the run should be applied automatically
+    And the command should wait for the apply to complete
+    And the command should exit with code 0

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -138,6 +138,7 @@ def test_trigger_speculative_plan():
 @scenario(
     "../features/run_lifecycle.feature",
     "Watching an externally triggered run and auto-applying after planning",
+    "Following an externally triggered run and auto-applying after planning",
 )
 def test_watch_auto_apply():
     pass
@@ -1138,3 +1139,18 @@ def watch_exit_zero(cli_result):
 @then("the command should exit with code 1")
 def watch_exit_one(cli_result):
     assert cli_result.exit_code == 1
+
+
+@when(
+    parsers.parse('I follow "{run_id}" with --auto-apply'),
+    target_fixture="cli_result",
+)
+def follow_with_auto_apply(mock_client, run_id):
+    with (
+        patch("terrapyne.cli.utils.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("time.sleep"),
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(app, ["run", "follow", run_id, "--auto-apply", "-o", "test-org"])


### PR DESCRIPTION
## Summary

Added `--auto-apply` and `--comment` flags to `terrapyne run follow` so it can automatically apply a run when it finishes planning.

---

## Why

**Driver:**
A user noticed that `terrapyne run follow` lacked the `--auto-apply` flag which was available on `run watch` and `run trigger`. When following an externally triggered run, this forced a manual step to chain the apply.

**Alternatives rejected:**
We could have just told users to use `run watch --auto-apply`, but `run follow` is better when you want real-time log streaming.

---

## What changed

**Affected:** src/terrapyne/cli/run_cmd.py · tests/test_cli/test_run_commands.py · tests/features/run_lifecycle.feature

---

## Risk and review focus

**Look here first:** The `stream_logs` callback logic in `run_follow` that intercepts `is_awaiting_approval` to trigger an apply.

**Edge cases left for later:**
None.

**Skip:**
The BDD test plumbing which just mirrors the `watch` test.

---

## Testing

**Scenarios tested:**
- Following an externally triggered run and auto-applying after planning

**Coverage delta:** Positive.

---

<details>
<summary>Pre-submission checklist</summary>

**Process**
- [x] PR title follows Conventional Commits format
- [x] Commits are atomic — code + tests together in each

**Quality**
- [x] `make test-fast` passes locally (lint + typecheck)
- [x] New code has tests — unit or BDD as appropriate

</details>