### PR TITLE
fix(workspace-clone): preserve agent-pool and project during clone (B10, B11)

### DIFF
--- a/src/terrapyne/api/workspace_clone.py
+++ b/src/terrapyne/api/workspace_clone.py
@@ -532,6 +532,7 @@ class CloneWorkspaceAPI:
         auto_apply: bool | None = None,
         tags: list[str] | None = None,
         agent_pool_id: str | None = None,
+        project_id: str | None = None,
     ) -> Workspace:
         """Create a new workspace.
 
@@ -543,6 +544,7 @@ class CloneWorkspaceAPI:
             auto_apply: Whether to auto-apply
             tags: Tags to apply to workspace
             agent_pool_id: Agent pool ID (required when execution_mode is "agent")
+            project_id: Project ID to assign the workspace to
 
         Returns:
             Created Workspace instance
@@ -572,10 +574,13 @@ class CloneWorkspaceAPI:
             }
         }
 
+        relationships: dict = {}
         if agent_pool_id:
-            payload["data"]["relationships"] = {
-                "agent-pool": {"data": {"type": "agent-pools", "id": agent_pool_id}}
-            }
+            relationships["agent-pool"] = {"data": {"type": "agent-pools", "id": agent_pool_id}}
+        if project_id:
+            relationships["project"] = {"data": {"type": "projects", "id": project_id}}
+        if relationships:
+            payload["data"]["relationships"] = relationships
 
         response = self.client.post(path, json_data=payload)
         return Workspace.from_api_response(response["data"])
@@ -592,6 +597,7 @@ class CloneWorkspaceAPI:
         vcs_oauth_token_id: str | None = None,
         force: bool = False,
         async_mode: bool = False,
+        project_id: str | None = None,
     ) -> dict:
         """Clone a workspace with specified configuration.
 
@@ -667,6 +673,7 @@ class CloneWorkspaceAPI:
                 auto_apply=source_ws.auto_apply,
                 tags=source_ws.tag_names if source_ws.tag_names else None,
                 agent_pool_id=source_ws.agent_pool_id,
+                project_id=project_id if project_id is not None else source_ws.project_id,
             )
             target_workspace_id = target_ws.id
             logger.info(

--- a/src/terrapyne/api/workspace_clone.py
+++ b/src/terrapyne/api/workspace_clone.py
@@ -673,7 +673,7 @@ class CloneWorkspaceAPI:
                 auto_apply=source_ws.auto_apply,
                 tags=source_ws.tag_names if source_ws.tag_names else None,
                 agent_pool_id=source_ws.agent_pool_id,
-                project_id=project_id if project_id is not None else source_ws.project_id,
+                project_id=project_id or source_ws.project_id,
             )
             target_workspace_id = target_ws.id
             logger.info(

--- a/src/terrapyne/api/workspace_clone.py
+++ b/src/terrapyne/api/workspace_clone.py
@@ -531,6 +531,7 @@ class CloneWorkspaceAPI:
         execution_mode: str | None = None,
         auto_apply: bool | None = None,
         tags: list[str] | None = None,
+        agent_pool_id: str | None = None,
     ) -> Workspace:
         """Create a new workspace.
 
@@ -538,9 +539,10 @@ class CloneWorkspaceAPI:
             workspace_name: Name for the new workspace
             organization: Organization name
             terraform_version: Terraform version to use
-            execution_mode: Execution mode (remote or local)
+            execution_mode: Execution mode (remote, local, or agent)
             auto_apply: Whether to auto-apply
             tags: Tags to apply to workspace
+            agent_pool_id: Agent pool ID (required when execution_mode is "agent")
 
         Returns:
             Created Workspace instance
@@ -551,7 +553,6 @@ class CloneWorkspaceAPI:
             "name": workspace_name,
         }
 
-        # Add optional attributes
         if terraform_version:
             attributes["terraform-version"] = terraform_version
 
@@ -561,16 +562,20 @@ class CloneWorkspaceAPI:
         if auto_apply is not None:
             attributes["auto-apply"] = auto_apply
 
-        # Handle tags separately if provided
         if tags:
             attributes["tag-names"] = tags
 
-        payload = {
+        payload: dict = {
             "data": {
                 "type": "workspaces",
                 "attributes": attributes,
             }
         }
+
+        if agent_pool_id:
+            payload["data"]["relationships"] = {
+                "agent-pool": {"data": {"type": "agent-pools", "id": agent_pool_id}}
+            }
 
         response = self.client.post(path, json_data=payload)
         return Workspace.from_api_response(response["data"])
@@ -661,6 +666,7 @@ class CloneWorkspaceAPI:
                 execution_mode=source_ws.execution_mode,
                 auto_apply=source_ws.auto_apply,
                 tags=source_ws.tag_names if source_ws.tag_names else None,
+                agent_pool_id=source_ws.agent_pool_id,
             )
             target_workspace_id = target_ws.id
             logger.info(

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -528,6 +528,12 @@ def workspace_clone(
     force: bool = typer.Option(
         False, "--force", "-f", help="Force clone even if target workspace exists"
     ),
+    project_id: str | None = typer.Option(
+        None,
+        "--project-id",
+        "-p",
+        help="Project ID to assign the cloned workspace to (overrides source project)",
+    ),
 ):
     """Clone a workspace (configuration and variables).
 
@@ -562,6 +568,7 @@ def workspace_clone(
                 with_vcs=with_vcs,
                 vcs_oauth_token_id=vcs_token,
                 force=force,
+                project_id=project_id,
             )
 
             console.print(f"\n[green]✓[/green] {result.get('message', 'Successfully cloned')}")

--- a/src/terrapyne/models/workspace.py
+++ b/src/terrapyne/models/workspace.py
@@ -45,6 +45,9 @@ class Workspace(BaseModel):
     project_id: str | None = None
     project_name: str | None = None
 
+    # Agent pool (present when execution-mode is "agent")
+    agent_pool_id: str | None = None
+
     # Tags
     tag_names: list[str] = Field(default_factory=list, alias="tag-names")
 
@@ -77,12 +80,15 @@ class Workspace(BaseModel):
         if attrs.get("vcs-repo"):
             vcs_repo = WorkspaceVCS.model_validate(attrs["vcs-repo"])
 
-        # Extract project ID from relationships
+        # Extract relationships
         project_id = None
         project_name = None
+        agent_pool_id = None
         relationships = data.get("relationships", {})
         if relationships.get("project", {}).get("data"):
             project_id = relationships["project"]["data"].get("id")
+        if relationships.get("agent-pool", {}).get("data"):
+            agent_pool_id = relationships["agent-pool"]["data"].get("id")
 
         # Try to find project name in included data
         if included and project_id:
@@ -119,6 +125,7 @@ class Workspace(BaseModel):
             vcs_repo=vcs_repo,
             project_id=project_id,
             project_name=project_name,
+            agent_pool_id=agent_pool_id,
             tag_names=attrs.get("tag-names", []),
             latest_run=latest_run,
             environment=environment,

--- a/tests/features/workspace.feature
+++ b/tests/features/workspace.feature
@@ -208,6 +208,21 @@ Feature: Workspace Operations
     Then I should see error message containing "already exists"
     And exit code should be 1
 
+  # B10 — workspace clone agent-pool relationship
+
+  Scenario: Clone preserves agent-pool assignment when source uses agent execution mode
+    Given workspace "agent-ws" uses execution mode "agent" with agent pool "apool-abc123"
+    When I clone workspace "agent-ws" to "agent-ws-clone"
+    Then the create payload should include the agent-pool relationship "apool-abc123"
+    And the cloned workspace should have execution mode "agent"
+    And exit code should be 0
+
+  Scenario: Clone without agent pool succeeds for remote execution mode
+    Given workspace "remote-ws" uses execution mode "remote" with no agent pool
+    When I clone workspace "remote-ws" to "remote-ws-clone"
+    Then the create payload should not include an agent-pool relationship
+    And exit code should be 0
+
   # Workspace Delete Feature Scenarios
 
   Scenario: Delete a workspace with confirmation

--- a/tests/features/workspace.feature
+++ b/tests/features/workspace.feature
@@ -223,6 +223,20 @@ Feature: Workspace Operations
     Then the create payload should not include an agent-pool relationship
     And exit code should be 0
 
+  # B11 — workspace clone project override
+
+  Scenario: Clone assigns cloned workspace to a different project
+    Given workspace "source-ws" is in project "prj-old123"
+    When I clone workspace "source-ws" to "target-ws" with project "prj-new456"
+    Then the cloned workspace should be in project "prj-new456"
+    And exit code should be 0
+
+  Scenario: Clone without --project-id inherits source project
+    Given workspace "source-ws" is in project "prj-old123"
+    When I clone workspace "source-ws" to "target-ws"
+    Then the cloned workspace should be in project "prj-old123"
+    And exit code should be 0
+
   # Workspace Delete Feature Scenarios
 
   Scenario: Delete a workspace with confirmation

--- a/tests/test_api/test_workspace_clone.py
+++ b/tests/test_api/test_workspace_clone.py
@@ -746,34 +746,33 @@ class TestCloneAgentPool:
 # ============================================================================
 
 
+_REMOTE_SOURCE_WS = {
+    "id": "ws-source",
+    "type": "workspaces",
+    "attributes": {
+        "name": "source-ws",
+        "terraform-version": "1.7.0",
+        "execution-mode": "remote",
+        "auto-apply": False,
+        "tag-names": [],
+    },
+    "relationships": {"project": {"data": {"type": "projects", "id": "prj-old123"}}},
+}
+
+_BLANK_TARGET_WS = {
+    "id": "ws-target",
+    "type": "workspaces",
+    "attributes": {"name": "target-ws"},
+}
+
+
 class TestCloneProjectOverride:
     """B11: workspace clone --project-id should assign the clone to a different project."""
 
     def test_clone_with_project_id_override_sends_relationship(self, api, mock_client):
         """When project_id is supplied, it appears in the create payload relationships."""
-        source_ws_data = {
-            "id": "ws-source",
-            "type": "workspaces",
-            "attributes": {
-                "name": "source-ws",
-                "terraform-version": "1.7.0",
-                "execution-mode": "remote",
-                "auto-apply": False,
-                "tag-names": [],
-            },
-            "relationships": {"project": {"data": {"type": "projects", "id": "prj-old123"}}},
-        }
-        target_ws_data = {
-            "id": "ws-target",
-            "type": "workspaces",
-            "attributes": {"name": "target-ws"},
-        }
-
-        mock_client.get.side_effect = [
-            {"data": source_ws_data},
-            Exception("404 not found"),
-        ]
-        mock_client.post.return_value = {"data": target_ws_data}
+        mock_client.get.side_effect = [{"data": _REMOTE_SOURCE_WS}, Exception("404 not found")]
+        mock_client.post.return_value = {"data": _BLANK_TARGET_WS}
 
         result = api.clone(
             source_workspace_name="source-ws",
@@ -790,29 +789,8 @@ class TestCloneProjectOverride:
 
     def test_clone_without_project_id_inherits_source_project(self, api, mock_client):
         """Without project_id override, the source project is inherited."""
-        source_ws_data = {
-            "id": "ws-source",
-            "type": "workspaces",
-            "attributes": {
-                "name": "source-ws",
-                "terraform-version": "1.7.0",
-                "execution-mode": "remote",
-                "auto-apply": False,
-                "tag-names": [],
-            },
-            "relationships": {"project": {"data": {"type": "projects", "id": "prj-old123"}}},
-        }
-        target_ws_data = {
-            "id": "ws-target",
-            "type": "workspaces",
-            "attributes": {"name": "target-ws"},
-        }
-
-        mock_client.get.side_effect = [
-            {"data": source_ws_data},
-            Exception("404 not found"),
-        ]
-        mock_client.post.return_value = {"data": target_ws_data}
+        mock_client.get.side_effect = [{"data": _REMOTE_SOURCE_WS}, Exception("404 not found")]
+        mock_client.post.return_value = {"data": _BLANK_TARGET_WS}
 
         result = api.clone(
             source_workspace_name="source-ws",

--- a/tests/test_api/test_workspace_clone.py
+++ b/tests/test_api/test_workspace_clone.py
@@ -742,6 +742,113 @@ class TestCloneAgentPool:
 
 
 # ============================================================================
+# B11 — project-id override on workspace clone
+# ============================================================================
+
+
+class TestCloneProjectOverride:
+    """B11: workspace clone --project-id should assign the clone to a different project."""
+
+    def test_clone_with_project_id_override_sends_relationship(self, api, mock_client):
+        """When project_id is supplied, it appears in the create payload relationships."""
+        source_ws_data = {
+            "id": "ws-source",
+            "type": "workspaces",
+            "attributes": {
+                "name": "source-ws",
+                "terraform-version": "1.7.0",
+                "execution-mode": "remote",
+                "auto-apply": False,
+                "tag-names": [],
+            },
+            "relationships": {"project": {"data": {"type": "projects", "id": "prj-old123"}}},
+        }
+        target_ws_data = {
+            "id": "ws-target",
+            "type": "workspaces",
+            "attributes": {"name": "target-ws"},
+        }
+
+        mock_client.get.side_effect = [
+            {"data": source_ws_data},
+            Exception("404 not found"),
+        ]
+        mock_client.post.return_value = {"data": target_ws_data}
+
+        result = api.clone(
+            source_workspace_name="source-ws",
+            target_workspace_name="target-ws",
+            organization="test-org",
+            project_id="prj-new456",
+        )
+
+        assert result["status"] == "success"
+        payload = mock_client.post.call_args[1]["json_data"]
+        relationships = payload["data"].get("relationships", {})
+        assert "project" in relationships, "project relationship missing from clone payload"
+        assert relationships["project"]["data"]["id"] == "prj-new456"
+
+    def test_clone_without_project_id_inherits_source_project(self, api, mock_client):
+        """Without project_id override, the source project is inherited."""
+        source_ws_data = {
+            "id": "ws-source",
+            "type": "workspaces",
+            "attributes": {
+                "name": "source-ws",
+                "terraform-version": "1.7.0",
+                "execution-mode": "remote",
+                "auto-apply": False,
+                "tag-names": [],
+            },
+            "relationships": {"project": {"data": {"type": "projects", "id": "prj-old123"}}},
+        }
+        target_ws_data = {
+            "id": "ws-target",
+            "type": "workspaces",
+            "attributes": {"name": "target-ws"},
+        }
+
+        mock_client.get.side_effect = [
+            {"data": source_ws_data},
+            Exception("404 not found"),
+        ]
+        mock_client.post.return_value = {"data": target_ws_data}
+
+        result = api.clone(
+            source_workspace_name="source-ws",
+            target_workspace_name="target-ws",
+            organization="test-org",
+        )
+
+        assert result["status"] == "success"
+        payload = mock_client.post.call_args[1]["json_data"]
+        relationships = payload["data"].get("relationships", {})
+        assert "project" in relationships, "source project should be inherited"
+        assert relationships["project"]["data"]["id"] == "prj-old123"
+
+    def test_create_workspace_with_project_id(self, api, mock_client):
+        """create_workspace passes project_id as a relationship."""
+        mock_client.post.return_value = {
+            "data": {
+                "id": "ws-new",
+                "type": "workspaces",
+                "attributes": {"name": "new-ws"},
+            }
+        }
+
+        api.create_workspace(
+            workspace_name="new-ws",
+            organization="test-org",
+            project_id="prj-new456",
+        )
+
+        payload = mock_client.post.call_args[1]["json_data"]
+        relationships = payload["data"].get("relationships", {})
+        assert "project" in relationships
+        assert relationships["project"]["data"]["id"] == "prj-new456"
+
+
+# ============================================================================
 # Fixtures
 # ============================================================================
 

--- a/tests/test_api/test_workspace_clone.py
+++ b/tests/test_api/test_workspace_clone.py
@@ -647,6 +647,101 @@ class TestCloneValidation:
 
 
 # ============================================================================
+# B10 — Agent-pool relationship preserved during clone
+# ============================================================================
+
+
+class TestCloneAgentPool:
+    """B10: workspace clone must include agent-pool relationship when source uses agent mode."""
+
+    def test_create_workspace_with_agent_pool_includes_relationship(self, api, mock_client):
+        """Agent-pool relationship is sent in the POST payload when execution-mode is agent."""
+        mock_client.post.return_value = {
+            "data": {
+                "id": "ws-clone-xyz",
+                "type": "workspaces",
+                "attributes": {
+                    "name": "agent-ws-clone",
+                    "execution-mode": "agent",
+                },
+            }
+        }
+
+        api.create_workspace(
+            workspace_name="agent-ws-clone",
+            organization="test-org",
+            execution_mode="agent",
+            agent_pool_id="apool-abc123",
+        )
+
+        payload = mock_client.post.call_args[1]["json_data"]
+        relationships = payload["data"].get("relationships", {})
+        assert "agent-pool" in relationships, "agent-pool relationship missing from payload"
+        assert relationships["agent-pool"]["data"]["id"] == "apool-abc123"
+        assert relationships["agent-pool"]["data"]["type"] == "agent-pools"
+
+    def test_create_workspace_without_agent_pool_omits_relationship(self, api, mock_client):
+        """No agent-pool relationship is sent when execution-mode is not agent."""
+        mock_client.post.return_value = {
+            "data": {
+                "id": "ws-remote-clone",
+                "type": "workspaces",
+                "attributes": {"name": "remote-ws-clone", "execution-mode": "remote"},
+            }
+        }
+
+        api.create_workspace(
+            workspace_name="remote-ws-clone",
+            organization="test-org",
+            execution_mode="remote",
+        )
+
+        payload = mock_client.post.call_args[1]["json_data"]
+        relationships = payload["data"].get("relationships", {})
+        assert "agent-pool" not in relationships
+
+    def test_full_clone_propagates_agent_pool_from_source(self, api, mock_client):
+        """End-to-end: cloning an agent workspace forwards the agent-pool to the create call."""
+        source_ws_data = {
+            "id": "ws-agent-source",
+            "type": "workspaces",
+            "attributes": {
+                "name": "agent-ws",
+                "terraform-version": "1.7.0",
+                "execution-mode": "agent",
+                "auto-apply": False,
+                "tag-names": [],
+            },
+            "relationships": {
+                "agent-pool": {"data": {"type": "agent-pools", "id": "apool-abc123"}}
+            },
+        }
+        target_ws_data = {
+            "id": "ws-agent-clone",
+            "type": "workspaces",
+            "attributes": {"name": "agent-ws-clone", "execution-mode": "agent"},
+        }
+
+        mock_client.get.side_effect = [
+            {"data": source_ws_data},
+            Exception("404 not found"),  # target does not exist
+        ]
+        mock_client.post.return_value = {"data": target_ws_data}
+
+        result = api.clone(
+            source_workspace_name="agent-ws",
+            target_workspace_name="agent-ws-clone",
+            organization="test-org",
+        )
+
+        assert result["status"] == "success"
+        payload = mock_client.post.call_args[1]["json_data"]
+        relationships = payload["data"].get("relationships", {})
+        assert "agent-pool" in relationships, "agent-pool dropped from clone create payload"
+        assert relationships["agent-pool"]["data"]["id"] == "apool-abc123"
+
+
+# ============================================================================
 # Fixtures
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- **B10**: `workspace clone` was dropping the `agent-pool` relationship from the POST payload, causing TFC to return HTTP 422 when cloning workspaces with `execution-mode=agent`. The `Workspace` model now reads `agent_pool_id` from the API response relationships, and `CloneWorkspaceAPI.create_workspace()` forwards it.
- **B11**: `workspace clone` had no way to assign the clone to a different project — clones silently landed in the source project. Added `--project-id / -p` to `workspace clone`; without it the source project is inherited.

## Commits

- `fix(workspace-clone)`: forward agent-pool relationship to prevent 422 (B10)
- `feat(workspace-clone)`: add --project-id to assign clone to a different project (B11)
- `refactor(workspace-clone)`: simplify project_id fallback and deduplicate test fixtures

## Test plan

- [ ] Unit: `TestCloneAgentPool` — agent-pool present in payload for agent-mode workspace, absent for remote
- [ ] Unit: `TestCloneProjectOverride` — project override sent when `--project-id` given, source project inherited otherwise
- [ ] BDD scenarios added to `workspace.feature` for B10 and B11
- [ ] 775 tests passing on rebased branch