### PR TITLE
fix(runs): Surface archivist log text for pre-plan failures (B7/B8)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,8 +27,8 @@ For evaluating live TFC behaviour, use:
 | # | Finding | Impact | Effort | WSJF | Status |
 |---|---|---|---|---|---|
 | **BUGS (May 2026)** |
-| B7 | `run follow` / `run logs` silent on pre-plan errors — falls back to `"Run failed before generating logs"` with no error text | 🔴 | S | 4.0 | ✅ |
-| B8 | `run logs` returns empty for errored runs even when log is available via archivist URL | 🔴 | S | 4.0 | ✅ |
+| B7 | `run follow` / `run logs` silent on pre-plan errors — falls back to `"Run failed before generating logs"` with no error text | 🔴 | S | 4.0 | ✅ [#114](https://github.com/shalomb/terrapyne/pull/114) |
+| B8 | `run logs` returns empty for errored runs even when log is available via archivist URL | 🔴 | S | 4.0 | ✅ [#114](https://github.com/shalomb/terrapyne/pull/114) |
 | B9 | `run list` fails by workspace name for some workspaces — requires workspace ID workaround | 🟡 | S | 2.0 | TODO |
 | B10 | `workspace clone` 422 "Agent pool not found" — drops agent-pool relationship from create payload | 🔴 | S | 4.0 | ✅ |
 | B11 | `workspace create` missing `--project` flag — no way to assign workspace to a project at creation | 🔴 | S | 4.0 | ✅ |

--- a/src/terrapyne/api/runs.py
+++ b/src/terrapyne/api/runs.py
@@ -311,43 +311,61 @@ class RunsAPI:
         response = self.client.get(path)
         return Plan.from_api_response(response["data"])
 
-    def get_plan_logs(self, plan_id: str) -> str:
+    def get_plan_logs(self, plan_id: str, log_read_url: str | None = None) -> str:
         """Get plan logs.
+
+        Fetches the streaming endpoint first. If that returns empty and a
+        ``log_read_url`` (archivist URL) is provided, falls back to it.
+        This covers B7/B8 where runs that fail pre-plan produce no streaming
+        output but do have an archivist log blob.
 
         Args:
             plan_id: Plan ID
+            log_read_url: Optional archivist URL from Plan.log_read_url
 
         Returns:
             Plan log content as string
-
-        Raises:
-            TFCAPIError: If logs not available (other than 404/403)
         """
         path = f"/plans/{plan_id}/logs"
         try:
-            return self.client._request("GET", path).text
+            content = self.client._request("GET", path).text
         except (TFCNotFoundError, TFCAuthenticationError):
-            # Logs might not be ready yet
-            return ""
+            content = ""
 
-    def get_apply_logs(self, apply_id: str) -> str:
+        if not content and log_read_url:
+            try:
+                content = self.client._request("GET", log_read_url).text
+            except (TFCNotFoundError, TFCAuthenticationError):
+                content = ""
+
+        return content
+
+    def get_apply_logs(self, apply_id: str, log_read_url: str | None = None) -> str:
         """Get apply logs.
+
+        Fetches the streaming endpoint first. If that returns empty and a
+        ``log_read_url`` (archivist URL) is provided, falls back to it.
 
         Args:
             apply_id: Apply ID
+            log_read_url: Optional archivist URL from Apply.log_read_url
 
         Returns:
             Apply log content as string
-
-        Raises:
-            TFCAPIError: If logs not available (other than 404/403)
         """
         path = f"/applies/{apply_id}/logs"
         try:
-            return self.client._request("GET", path).text
+            content = self.client._request("GET", path).text
         except (TFCNotFoundError, TFCAuthenticationError):
-            # Logs might not be ready yet
-            return ""
+            content = ""
+
+        if not content and log_read_url:
+            try:
+                content = self.client._request("GET", log_read_url).text
+            except (TFCNotFoundError, TFCAuthenticationError):
+                content = ""
+
+        return content
 
     def get_error_summary(self, run: Run) -> str:
         """Extract the Terraform error text from an errored run.
@@ -371,14 +389,29 @@ class RunsAPI:
         if not run.plan_id:
             return fallback
 
+        plan_log_read_url: str | None = None
+        apply_log_read_url: str | None = None
+        try:
+            plan_log_read_url = self.get_plan(run.plan_id).log_read_url
+        except Exception:
+            pass
+
         if run.plan_status == "finished" or (run.plan_status is None and run.apply_id):
             # Plan succeeded (or status unknown but apply exists) — try apply log first
-            raw = self.get_apply_logs(run.apply_id) if run.apply_id else ""
+            if run.apply_id:
+                try:
+                    apply_log_read_url = self.get_apply(run.apply_id).log_read_url
+                except Exception:
+                    pass
+            raw = (
+                self.get_apply_logs(run.apply_id, log_read_url=apply_log_read_url)
+                if run.apply_id
+                else ""
+            )
             if not raw:
-                # Apply log empty; error may still be in the plan log
-                raw = self.get_plan_logs(run.plan_id)
+                raw = self.get_plan_logs(run.plan_id, log_read_url=plan_log_read_url)
         else:
-            raw = self.get_plan_logs(run.plan_id)
+            raw = self.get_plan_logs(run.plan_id, log_read_url=plan_log_read_url)
 
         clean = _ANSI_ESCAPE.sub("", raw)
         error_lines = [

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -237,12 +237,22 @@ def run_logs(
             if not run.plan_id:
                 console.print("[yellow]No plan logs available for this run.[/yellow]")
                 return
-            logs = client.runs.get_plan_logs(run.plan_id)
+            plan = None
+            with suppress(Exception):
+                plan = client.runs.get_plan(run.plan_id)
+            logs = client.runs.get_plan_logs(
+                run.plan_id, log_read_url=plan.log_read_url if plan else None
+            )
         elif stage == "apply":
             if not run.apply_id:
                 console.print("[yellow]No apply logs available for this run.[/yellow]")
                 return
-            logs = client.runs.get_apply_logs(run.apply_id)
+            apply_obj = None
+            with suppress(Exception):
+                apply_obj = client.runs.get_apply(run.apply_id)
+            logs = client.runs.get_apply_logs(
+                run.apply_id, log_read_url=apply_obj.log_read_url if apply_obj else None
+            )
         else:
             console.print(f"[red]Error: Invalid stage '{stage}'. Use 'plan' or 'apply'.[/red]")
             raise typer.Exit(1)
@@ -738,9 +748,15 @@ def run_follow(
         last_plan_pos = 0
         last_apply_pos = 0
         current_stage = None
+        plan_url_fetched = False
+        plan_log_read_url: str | None = None
+        apply_url_fetched = False
+        apply_log_read_url: str | None = None
 
         def stream_logs(run: Run) -> None:
             nonlocal last_plan_pos, last_apply_pos, current_stage
+            nonlocal plan_url_fetched, plan_log_read_url
+            nonlocal apply_url_fetched, apply_log_read_url
 
             # 1. Plan Stage
             if run.plan_id:
@@ -748,7 +764,12 @@ def run_follow(
                     current_stage = "plan"
                     console.print("[dim]📋 Plan:[/dim]")
                 try:
-                    plan_log = client.runs.get_plan_logs(run.plan_id)
+                    if not plan_url_fetched:
+                        plan_log_read_url = client.runs.get_plan(run.plan_id).log_read_url
+                        plan_url_fetched = True
+                    plan_log = client.runs.get_plan_logs(
+                        run.plan_id, log_read_url=plan_log_read_url
+                    )
                     last_plan_pos = _print_log_delta(plan_log, last_plan_pos)
                 except Exception:
                     pass
@@ -759,7 +780,12 @@ def run_follow(
                     current_stage = "apply"
                     console.print("\n[dim]⚙️  Apply:[/dim]")
                 try:
-                    apply_log = client.runs.get_apply_logs(run.apply_id)
+                    if not apply_url_fetched:
+                        apply_log_read_url = client.runs.get_apply(run.apply_id).log_read_url
+                        apply_url_fetched = True
+                    apply_log = client.runs.get_apply_logs(
+                        run.apply_id, log_read_url=apply_log_read_url
+                    )
                     last_apply_pos = _print_log_delta(apply_log, last_apply_pos)
                 except Exception:
                     pass

--- a/tests/features/run_details.feature
+++ b/tests/features/run_details.feature
@@ -43,3 +43,9 @@ Feature: Run Details and Diagnostics
     When I attempt to examine its details
     Then I should be notified that the record was not found
     And the request should not proceed
+
+  Scenario: Viewing logs for a run that failed before generating plan output
+    Given the run "run-prefail123" errored before the plan stage produced output
+    When I retrieve the logs for run "run-prefail123"
+    Then the output should contain "Error: Invalid provider configuration"
+    And the output should not say "empty or not yet ready"

--- a/tests/features/run_lifecycle.feature
+++ b/tests/features/run_lifecycle.feature
@@ -83,3 +83,9 @@ Feature: Infrastructure Change Lifecycle
     When I watch "run-ext-789" with --auto-apply
     Then the run should not be applied
     And the command should exit with code 1
+
+  Scenario: Following a run that fails before producing plan output shows archivist error text
+    Given an externally triggered run "run-prefail-001" errored before generating plan logs
+    When I follow "run-prefail-001"
+    Then the output should contain "Error: Invalid provider configuration"
+    And the output should not show "Run failed before generating logs"

--- a/tests/test_api/test_run_error_summary.py
+++ b/tests/test_api/test_run_error_summary.py
@@ -224,3 +224,123 @@ class TestGetErrorSummary:
         assert apply_idx is not None, "Apply log was never fetched"
         assert plan_idx is not None, "Plan log was never fetched"
         assert apply_idx < plan_idx, "Apply log must be tried before plan log"
+
+    def test_pre_plan_failure_uses_archivist_url_via_get_plan(self, api, mock_client):
+        """Pre-plan failure: get_error_summary fetches the Plan to get log_read_url (B7/B8)."""
+        run = _make_run("run-pre-plan", plan_status="errored", apply_id=None)
+        archivist_url = "https://archivist.terraform.io/v1/object/pre-plan"
+
+        mock_client.get.return_value = {
+            "data": {
+                "id": "plan-abc",
+                "type": "plans",
+                "attributes": {
+                    "status": "errored",
+                    "log-read-url": archivist_url,
+                    "has-changes": False,
+                    "resource-additions": 0,
+                    "resource-changes": 0,
+                    "resource-destructions": 0,
+                    "resource-imports": 0,
+                    "action-invocations": 0,
+                },
+            }
+        }
+
+        def fake_request(method, path, **_kwargs):
+            m = MagicMock()
+            m.text = "Error: Invalid provider configuration\n" if path == archivist_url else ""
+            return m
+
+        mock_client._request.side_effect = fake_request
+
+        summary = api.get_error_summary(run)
+
+        assert "Invalid provider configuration" in summary
+        called_paths = [c.args[1] for c in mock_client._request.call_args_list]
+        assert any(p == archivist_url for p in called_paths)
+
+
+class TestLogReadUrlFallback:
+    """B7/B8: get_plan_logs and get_apply_logs fall back to log_read_url when streaming is empty."""
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def api(self, mock_client):
+        return RunsAPI(mock_client)
+
+    def test_get_plan_logs_falls_back_to_log_read_url_when_streaming_empty(self, api, mock_client):
+        """When /plans/{id}/logs returns empty, fetch log_read_url instead (B7/B8)."""
+        archivist_url = "https://archivist.terraform.io/v1/object/abc"
+        archivist_content = "Error: Invalid provider configuration\n"
+
+        def fake_request(method, path, **_kwargs):
+            m = MagicMock()
+            m.text = archivist_content if path == archivist_url else ""
+            return m
+
+        mock_client._request.side_effect = fake_request
+
+        result = api.get_plan_logs("plan-abc", log_read_url=archivist_url)
+
+        assert result == archivist_content
+        called_paths = [c.args[1] for c in mock_client._request.call_args_list]
+        assert any("plans" in p and "logs" in p for p in called_paths), "streaming endpoint called"
+        assert any(p == archivist_url for p in called_paths), "archivist fallback called"
+
+    def test_get_plan_logs_no_fallback_when_streaming_has_content(self, api, mock_client):
+        """When /plans/{id}/logs returns content, log_read_url is not fetched."""
+        streaming_content = "Terraform will perform the following actions...\n"
+        mock_client._request.return_value.text = streaming_content
+
+        result = api.get_plan_logs(
+            "plan-abc", log_read_url="https://archivist.terraform.io/v1/object/abc"
+        )
+
+        assert result == streaming_content
+        assert mock_client._request.call_count == 1
+        called_path = mock_client._request.call_args.args[1]
+        assert "plans" in called_path and "logs" in called_path
+
+    def test_get_plan_logs_no_fallback_when_no_log_read_url(self, api, mock_client):
+        """When log_read_url is not provided and streaming is empty, return empty."""
+        mock_client._request.return_value.text = ""
+
+        result = api.get_plan_logs("plan-abc")
+
+        assert result == ""
+        assert mock_client._request.call_count == 1
+
+    def test_get_apply_logs_falls_back_to_log_read_url_when_streaming_empty(self, api, mock_client):
+        """When /applies/{id}/logs returns empty, fetch log_read_url instead (B7/B8)."""
+        archivist_url = "https://archivist.terraform.io/v1/object/xyz"
+        archivist_content = "Error: apply failed\n"
+
+        def fake_request(method, path, **_kwargs):
+            m = MagicMock()
+            m.text = archivist_content if path == archivist_url else ""
+            return m
+
+        mock_client._request.side_effect = fake_request
+
+        result = api.get_apply_logs("apply-abc", log_read_url=archivist_url)
+
+        assert result == archivist_content
+        called_paths = [c.args[1] for c in mock_client._request.call_args_list]
+        assert any("applies" in p and "logs" in p for p in called_paths)
+        assert any(p == archivist_url for p in called_paths)
+
+    def test_get_apply_logs_no_fallback_when_streaming_has_content(self, api, mock_client):
+        """When /applies/{id}/logs returns content, log_read_url is not fetched."""
+        streaming_content = "Apply complete! Resources: 2 added.\n"
+        mock_client._request.return_value.text = streaming_content
+
+        result = api.get_apply_logs(
+            "apply-abc", log_read_url="https://archivist.terraform.io/v1/object/xyz"
+        )
+
+        assert result == streaming_content
+        assert mock_client._request.call_count == 1

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -1138,3 +1138,165 @@ def watch_exit_zero(cli_result):
 @then("the command should exit with code 1")
 def watch_exit_one(cli_result):
     assert cli_result.exit_code == 1
+
+
+@when(
+    parsers.parse('I follow "{run_id}" with --auto-apply'),
+    target_fixture="cli_result",
+)
+def follow_with_auto_apply(mock_client, run_id):
+    with (
+        patch("terrapyne.cli.utils.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("time.sleep"),
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(app, ["run", "follow", run_id, "--auto-apply", "-o", "test-org"])
+
+
+# ============================================================================
+# B7/B8 — Pre-plan failure: archivist log fallback
+# ============================================================================
+
+_ARCHIVIST_ERROR = "Error: Invalid provider configuration"
+_ARCHIVIST_URL = "https://archivist.terraform.io/v1/object/prefail"
+
+
+@scenario(
+    "../features/run_lifecycle.feature",
+    "Following a run that fails before producing plan output shows archivist error text",
+)
+def test_follow_pre_plan_failure_shows_archivist_logs():
+    pass
+
+
+@scenario(
+    "../features/run_details.feature",
+    "Viewing logs for a run that failed before generating plan output",
+)
+def test_run_logs_pre_plan_failure_shows_archivist_content():
+    pass
+
+
+@given(
+    parsers.parse('an externally triggered run "{run_id}" errored before generating plan logs'),
+    target_fixture="mock_client",
+)
+def pre_plan_failure_run(run_id):
+    from terrapyne.models.plan import Plan
+
+    m = MagicMock()
+    errored_run = Run.model_construct(
+        id=run_id,
+        status=RunStatus.ERRORED,
+        plan_id="plan-prefail",
+        apply_id=None,
+    )
+    plan_obj = Plan.model_construct(
+        id="plan-prefail",
+        status="errored",
+        log_read_url=_ARCHIVIST_URL,
+    )
+    m.runs.get.return_value = errored_run
+    m.runs.get_plan.return_value = plan_obj
+    m.runs.get_plan_logs.return_value = _ARCHIVIST_ERROR
+    m.runs.poll_until_complete.return_value = errored_run
+    return m
+
+
+@when(
+    parsers.parse('I follow "{run_id}"'),
+    target_fixture="cli_result",
+)
+def follow_run(mock_client, run_id):
+    with (
+        patch("terrapyne.cli.run_cmd.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+
+        def mock_poll(run_id, callback, max_wait):
+            errored = Run.model_construct(
+                id=run_id,
+                status=RunStatus.ERRORED,
+                plan_id="plan-prefail",
+            )
+            callback(errored)
+            return errored
+
+        mock_client.runs.poll_until_complete.side_effect = mock_poll
+        result = runner.invoke(app, ["run", "follow", run_id, "-o", "test-org"])
+        result.mock_client = mock_client
+        return result
+
+
+@then(parsers.parse('the output should contain "{text}"'))
+def output_contains(cli_result, text):
+    assert text in cli_result.stdout
+
+
+@then(parsers.parse('the output should not show "{text}"'))
+def output_does_not_contain(cli_result, text):
+    assert text not in cli_result.stdout
+    call_kwargs = cli_result.mock_client.runs.get_plan_logs.call_args
+    assert call_kwargs is not None, "get_plan_logs was never called"
+    assert call_kwargs.kwargs.get("log_read_url") == _ARCHIVIST_URL, (
+        f"get_plan_logs not called with log_read_url={_ARCHIVIST_URL!r}"
+    )
+
+
+# ============================================================================
+# B7/B8 — run logs: pre-plan failure shows archivist content
+# ============================================================================
+
+
+@given(
+    parsers.parse('the run "{run_id}" errored before the plan stage produced output'),
+    target_fixture="pre_plan_logs_client",
+)
+def run_errored_pre_plan(run_id):
+    from terrapyne.models.plan import Plan
+
+    m = MagicMock()
+    errored_run = Run.model_construct(
+        id=run_id,
+        status=RunStatus.ERRORED,
+        plan_id="plan-prefail-logs",
+    )
+    plan_obj = Plan.model_construct(
+        id="plan-prefail-logs",
+        status="errored",
+        log_read_url=_ARCHIVIST_URL,
+    )
+    m.runs.get.return_value = errored_run
+    m.runs.get_plan.return_value = plan_obj
+    m.runs.get_plan_logs.return_value = _ARCHIVIST_ERROR + "\n"
+    return m
+
+
+@when(
+    parsers.parse('I retrieve the logs for run "{run_id}"'),
+    target_fixture="cli_result",
+)
+def retrieve_run_logs(pre_plan_logs_client, run_id):
+    with (
+        patch("terrapyne.cli.run_cmd.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = pre_plan_logs_client
+        result = runner.invoke(app, ["run", "logs", run_id, "-o", "test-org"])
+        result.mock_client = pre_plan_logs_client
+        return result
+
+
+@then(parsers.parse('the output should not say "{text}"'))
+def output_not_say(cli_result, text):
+    assert text not in cli_result.stdout
+    call_kwargs = cli_result.mock_client.runs.get_plan_logs.call_args
+    assert call_kwargs is not None, "get_plan_logs was never called"
+    assert call_kwargs.kwargs.get("log_read_url") == _ARCHIVIST_URL, (
+        "get_plan_logs not called with the plan's log_read_url"
+    )


### PR DESCRIPTION
## Problem

When a TFC run errors before Terraform generates any plan output (e.g. invalid provider configuration, missing variable), the streaming log endpoint `/plans/{id}/logs` returns an empty string. This caused three commands to silently swallow the actual error:

- `run logs` — printed "Logs for plan stage are empty or not yet ready"
- `run follow` — printed "Run failed before generating logs: errored"  
- `run errors` — fell back to `run.message` instead of the Terraform error text

## Solution

The TFC API exposes a `log-read-url` (archivist blob URL) on `Plan` and `Apply` objects. When the streaming endpoint returns empty, fetch the archivist blob as a fallback.

### Changes

**API layer (`runs.py`)**
- `get_plan_logs(plan_id, log_read_url=None)` — fetches archivist URL when streaming is empty
- `get_apply_logs(apply_id, log_read_url=None)` — same pattern
- `get_error_summary()` — fetches `Plan`/`Apply` objects to extract `log_read_url` before calling log methods

**CLI layer (`run_cmd.py`)**
- `run logs` — fetches `Plan`/`Apply` to pass `log_read_url` through
- `run follow` — fetches `Plan`/`Apply` once per session via bool guard (avoids repeated API calls on every poll iteration)

## Testing

Full Red → Green → Refactor cycle:

- BDD scenarios added to `run_details.feature` and `run_lifecycle.feature`
- `TestLogReadUrlFallback` — unit tests for the API fallback logic
- `TestGetErrorSummary::test_pre_plan_failure_uses_archivist_url_via_get_plan` — covers `get_error_summary` path
- pytest-bdd CLI integration tests assert `log_read_url` is passed as a kwarg (not just that output appears)
- 71 tests pass

## Closes

- B7: `run follow` / `run logs` silent on pre-plan errors
- B8: `run logs` returns empty for errored runs when log available via archivist URL