### PR TITLE
refactor(workspace): introduce workspace var subgroup and sync cli-reference (A18, D10)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -722,5 +722,46 @@ terrapyne run trigger tec-dce-inn-dev-93400-shalombhooshi && echo "triggered"
 - Refactor `var-set`, `var-rm`, `var-copy`, and `variables` into a new `workspace var` subcommand group.
 - Example: `tfc workspace var list`, `tfc workspace var set`.
 
+---
 
+## Agent Experience (AX) Epic
+
+These features are specifically designed to reduce the "glue logic" (bash pipes, `jq`, `grep`, `while` loops) that AI coding agents must write to orchestrate complex TFC workflows.
+
+### AX1 — Universal ID Resolver Utility
+**Context**: When agents need to fallback to raw `curl` for unsupported API endpoints, they need the exact TFC ID (e.g. `ws-*`, `prj-*`, `team-*`). Currently they must run `list` or `show --format json` and pipe to `jq`.
+**Fix**: Add an `id` command to all entity subgroups that prints ONLY the raw ID string to stdout.
+**Success Criteria**:
+- `terrapyne workspace id my-ws` outputs `ws-xyz123`
+- `terrapyne project id my-project` outputs `prj-xyz123`
+
+### AX2 — The "Latest Run" Lookups
+**Context**: Triggering an action on the most recent run requires listing runs, parsing JSON, extracting the first element's ID, and passing it to the next command.
+**Fix**: Add a `--latest` flag to run read commands (`run show`, `run logs`).
+**Success Criteria**:
+- `terrapyne run logs --workspace my-ws --latest` works without needing a run ID.
+
+### AX3 — The "Trigger and Wait" Loop
+**Context**: CI/CD automation and agents hate writing `while` loops to poll run status. `run follow` exists but streams verbose logs which bloats context windows.
+**Fix**: Add a `--wait` flag to `run trigger` that blocks until the run hits a terminal state, returning a non-zero exit code if it errored, without streaming logs.
+**Success Criteria**:
+- `terrapyne run trigger my-ws --wait` pauses execution silently and exits 0 on applied, or >0 on errored/canceled.
+
+### AX4 — State Output Extraction
+**Context**: Passing outputs from one workspace to another requires parsing the full state JSON payload.
+**Fix**: Add a dedicated `state output` command to extract a single raw output value.
+**Success Criteria**:
+- `terrapyne state output my-ws vpc_id` prints the raw string value of the output.
+
+### AX5 — Structured & Parseable Output for Mutations
+**Context**: While read commands support `--format json`, mutation commands (create, clone, trigger) only print rich console text. Agents need JSON to reliably capture newly created IDs without parsing ANSI text.
+**Fix**: Add a `--format json` flag (or ensure `--json` works globally) to all mutation commands (`workspace create`, `workspace clone`, `run trigger`).
+**Success Criteria**:
+- `terrapyne workspace create my-ws --format json` prints a JSON object with the new workspace ID.
+
+### AX6 — Idempotence and Safe Retries
+**Context**: If an agent runs `workspace create` and gets interrupted, running it again fails with a 409 Conflict. Agents often retry on error, creating a loop.
+**Fix**: Add idempotency flags to mutation commands, such as `--ignore-exists` for `workspace create`.
+**Success Criteria**:
+- `terrapyne workspace create my-ws --ignore-exists` succeeds (or exits gracefully without a fatal error) if the workspace is already provisioned.
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -18,12 +18,31 @@ Workspace management and inspection.
 - `show`: Show detailed workspace information.
 - `health`: Show workspace health snapshot (status, active runs, latest commit).
 - `vcs`: Show VCS configuration for a workspace.
-- `variables`: List variables in a workspace.
-- `var-set`: Create or update workspace variables (supports bulk setting).
-- `var-copy`: Copy all variables from one workspace to another.
+- `variables`: List variables in a workspace. *(Legacy — prefer `workspace var list`)*
+- `var-set`: Create or update workspace variables. *(Legacy — prefer `workspace var set`)*
+- `var-rm`: Remove a workspace variable. *(Legacy — prefer `workspace var remove`)*
+- `var-copy`: Copy all variables from one workspace to another. *(Legacy — prefer `workspace var copy`)*
 - `open`: Open workspace in browser.
 - `clone`: Clone a workspace with optional variables and VCS configuration.
+- `create`: Create a new workspace.
+- `update`: Update workspace configuration (name, Terraform version, execution mode, project).
+- `delete`: Delete a workspace.
 - `costs`: Show workspace TCO — total monthly cost from the latest cost estimate.
+
+### `tfc workspace var`
+Unified variable management subgroup.
+
+- `list`: List variables for a workspace.
+- `set`: Create or update a variable (`--key`, `--value`, `--category`, `--sensitive`).
+- `remove`: Remove a variable by key (`--force` to skip confirmation).
+- `copy`: Copy all variables from one workspace to another (`--overwrite` to replace existing).
+
+### `tfc workspace triggers`
+Run trigger relationship management.
+
+- `list`: List upstream run trigger sources for a workspace.
+- `add`: Add an upstream workspace as a run trigger source (`--source`).
+- `remove`: Remove a run trigger by its ID (`--trigger-id`, `--force`).
 
 ---
 
@@ -80,12 +99,22 @@ Team and membership management.
 
 ---
 
+## `tfc varset`
+Variable set management.
+
+- `list`: List variable sets in an organization.
+- `show`: Show variables in a variable set.
+- `apply`: Apply a variable set to a workspace (`--workspace`).
+- `remove`: Remove a variable set from a workspace (`--workspace`).
+
+---
+
 ## `tfc vcs`
 VCS connection and repository management.
 
-- `show`: Show VCS configuration for workspace.
-- `update-branch`: Update VCS branch for workspace.
-- `repos`: List GitHub repositories connected to TFC workspaces.
+- `list`: List VCS connections in an organization.
+- `show`: Show VCS configuration for a workspace.
+- `repos`: List available repositories for all VCS connections.
 
 ---
 

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -300,19 +300,8 @@ def workspace_variables(
         help="TFC organization (auto-detected from context if available)",
     ),
 ):
-    """List variables for a workspace."""
-    org, ws_name = validate_context(organization, workspace, require_workspace=True)
-
-    with get_client(ctx, organization=org) as client:
-        ws = client.workspaces.get(cast(str, ws_name), org)
-
-        variables = client.workspaces.get_variables(ws.id)
-
-        if not variables:
-            console.print("[yellow]No variables configured in this workspace.[/yellow]")
-            return
-
-        render_workspace_variables(variables)
+    """List variables for a workspace. (Legacy alias for 'workspace var list')"""
+    var_list(ctx, workspace=workspace, organization=organization)
 
 
 @app.command("var-set")
@@ -344,45 +333,18 @@ def workspace_var_set(
         ),
     ] = None,
 ):
-    """Set a workspace variable (create or update)."""
-    if key is None or value is None:
-        console.print("[red]Error: Both --key and --value are required.[/red]")
-        raise typer.Exit(1)
-
-    org, ws_name = validate_context(organization, workspace, require_workspace=True)
-
-    with get_client(ctx, organization=org) as client:
-        ws = client.workspaces.get(cast(str, ws_name), org)
-
-        # Check if variable already exists
-        variables: list[WorkspaceVariable] = client.workspaces.get_variables(ws.id)
-        if variables is None:
-            variables = []
-
-        existing_var = next((v for v in variables if v.key == key), None)
-
-        if existing_var:
-            console.print(f"[dim]Updating existing variable:[/dim] {key}")
-            client.workspaces.update_variable(
-                variable_id=existing_var.id,
-                value=value,
-                hcl=hcl,
-                sensitive=sensitive,
-                description=description,
-            )
-            console.print(f"[green]✓[/green] Updated variable: {key}")
-        else:
-            console.print(f"[dim]Creating new variable:[/dim] {key}")
-            client.workspaces.create_variable(
-                workspace_id=ws.id,
-                key=key,
-                value=value,
-                category=category,
-                hcl=hcl,
-                sensitive=sensitive,
-                description=description,
-            )
-            console.print(f"[green]✓[/green] Created variable: {key}")
+    """Set a workspace variable (create or update). (Legacy alias for 'workspace var set')"""
+    var_set(
+        ctx,
+        workspace=workspace,
+        key=key,
+        value=value,
+        category=category,
+        hcl=hcl,
+        sensitive=sensitive,
+        description=description,
+        organization=organization,
+    )
 
 
 @app.command("var-rm")
@@ -406,33 +368,8 @@ def workspace_var_rm(
     ] = None,
     force: Annotated[bool, typer.Option("--force", "-f", help="Skip confirmation")] = False,
 ):
-    """Remove a workspace variable."""
-    if key is None:
-        console.print("[red]Error: Variable key is required.[/red]")
-        raise typer.Exit(1)
-
-    org, ws_name = validate_context(organization, workspace, require_workspace=True)
-
-    with get_client(ctx, organization=org) as client:
-        ws = client.workspaces.get(cast(str, ws_name), org)
-
-        # Find variable by key
-        variables: list[WorkspaceVariable] = client.workspaces.get_variables(ws.id)
-        if variables is None:
-            variables = []
-
-        existing_var = next((v for v in variables if v.key == key), None)
-
-        if not existing_var:
-            console.print(f"[yellow]Variable '{key}' not found in workspace '{ws_name}'[/yellow]")
-            raise typer.Exit(1)
-
-        if not force and not typer.confirm(f"Remove variable '{key}' from workspace '{ws_name}'?"):
-            console.print("[yellow]Aborted.[/yellow]")
-            raise typer.Exit(0)
-
-        client.workspaces.delete_variable(workspace_id=ws.id, variable_id=existing_var.id)
-        console.print(f"[green]✓[/green] Removed variable: {key}")
+    """Remove a workspace variable. (Legacy alias for 'workspace var remove')"""
+    var_remove(ctx, workspace=workspace, key=key, organization=organization, force=force)
 
 
 @app.command("var-copy")
@@ -444,60 +381,8 @@ def workspace_var_copy(
     organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
     overwrite: bool = typer.Option(False, "--overwrite", help="Overwrite existing variables"),
 ):
-    """Copy all variables from one workspace to another."""
-    org, _ = validate_context(organization)
-
-    with get_client(ctx, organization=org) as client:
-        ws_source = client.workspaces.get(source, org)
-        ws_target = client.workspaces.get(target, org)
-
-        source_variables: list[WorkspaceVariable] = client.workspaces.get_variables(ws_source.id)
-        target_variables: list[WorkspaceVariable] = client.workspaces.get_variables(ws_target.id)
-
-        if source_variables is None:
-            source_variables = []
-        if target_variables is None:
-            target_variables = []
-
-        target_keys = {v.key for v in target_variables}
-
-        console.print(f"[dim]Copying {len(source_variables)} variables: {source} → {target}[/dim]")
-
-        copied = 0
-        skipped = 0
-        updated = 0
-
-        for var in source_variables:
-            if var.key in target_keys:
-                if overwrite:
-                    # Find target var ID
-                    t_v = next(v for v in target_variables if v.key == var.key)
-                    client.workspaces.update_variable(
-                        variable_id=t_v.id,
-                        value=var.value,
-                        hcl=var.hcl,
-                        sensitive=var.sensitive,
-                        description=var.description,
-                    )
-                    updated += 1
-                else:
-                    skipped += 1
-                    continue
-            else:
-                client.workspaces.create_variable(
-                    workspace_id=ws_target.id,
-                    key=var.key,
-                    value=var.value or "",
-                    category=var.category,
-                    hcl=var.hcl,
-                    sensitive=var.sensitive,
-                    description=var.description,
-                )
-                copied += 1
-
-        console.print(
-            f"[green]✓[/green] Done! {copied} created, {updated} updated, {skipped} skipped."
-        )
+    """Copy all variables from one workspace to another. (Legacy alias for 'workspace var copy')"""
+    var_copy(ctx, source=source, target=target, organization=organization, overwrite=overwrite)
 
 
 @app.command("open")

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -24,6 +24,15 @@ from terrapyne.rendering.rich_tables import (
 app = typer.Typer(help="Workspace management commands")
 app.add_typer(triggers_cmd.app, name="triggers")
 
+var_app = typer.Typer(help="Workspace variable management")
+app.add_typer(var_app, name="var")
+
+
+@var_app.callback(invoke_without_command=True)
+def _var_show_help(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
+
 
 @app.callback(invoke_without_command=True)
 def _show_help(ctx: typer.Context):
@@ -855,3 +864,209 @@ def workspace_costs(
 
         console.print(f"Estimated monthly cost: ${monthly_val:,.2f}")
         console.print(f"Cost delta: {delta_prefix}{delta_val:,.2f}")
+
+
+# ---------------------------------------------------------------------------
+# workspace var subgroup — delegates to existing workspace_variable* logic
+# ---------------------------------------------------------------------------
+
+
+@var_app.command("list")
+@handle_cli_errors
+def var_list(
+    ctx: typer.Context,
+    workspace: str | None = typer.Argument(
+        None, help="Workspace name (auto-detected from terraform.tf if in terraform directory)"
+    ),
+    organization: str | None = typer.Option(
+        None,
+        "--organization",
+        "-o",
+        help="TFC organization (auto-detected from context if available)",
+    ),
+):
+    """List variables for a workspace."""
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(cast(str, ws_name), org)
+        variables = client.workspaces.get_variables(ws.id)
+
+        if not variables:
+            console.print("[yellow]No variables configured in this workspace.[/yellow]")
+            return
+
+        render_workspace_variables(variables)
+
+
+@var_app.command("set")
+@handle_cli_errors
+def var_set(
+    ctx: typer.Context,
+    workspace: Annotated[
+        str | None,
+        typer.Argument(
+            help="Workspace name (auto-detected from terraform.tf if in terraform directory)"
+        ),
+    ] = None,
+    key: Annotated[str | None, typer.Option("--key", "-k", help="Variable key")] = None,
+    value: Annotated[str | None, typer.Option("--value", "-v", help="Variable value")] = None,
+    category: Annotated[
+        str, typer.Option("--category", "-c", help="Category: terraform, env")
+    ] = "terraform",
+    hcl: Annotated[bool, typer.Option("--hcl", help="Parse value as HCL")] = False,
+    sensitive: Annotated[bool, typer.Option("--sensitive", "-s", help="Mark as sensitive")] = False,
+    description: Annotated[
+        str | None, typer.Option("--description", "-d", help="Variable description")
+    ] = None,
+    organization: Annotated[
+        str | None,
+        typer.Option(
+            "--organization",
+            "-o",
+            help="TFC organization (auto-detected from context if available)",
+        ),
+    ] = None,
+):
+    """Set a workspace variable (create or update)."""
+    if key is None or value is None:
+        console.print("[red]Error: Both --key and --value are required.[/red]")
+        raise typer.Exit(1)
+
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(cast(str, ws_name), org)
+        variables: list[WorkspaceVariable] = client.workspaces.get_variables(ws.id) or []
+        existing_var = next((v for v in variables if v.key == key), None)
+
+        if existing_var:
+            console.print(f"[dim]Updating existing variable:[/dim] {key}")
+            client.workspaces.update_variable(
+                variable_id=existing_var.id,
+                value=value,
+                hcl=hcl,
+                sensitive=sensitive,
+                description=description,
+            )
+            console.print(f"[green]✓[/green] Updated variable: {key}")
+        else:
+            console.print(f"[dim]Creating new variable:[/dim] {key}")
+            client.workspaces.create_variable(
+                workspace_id=ws.id,
+                key=key,
+                value=value,
+                category=category,
+                hcl=hcl,
+                sensitive=sensitive,
+                description=description,
+            )
+            console.print(f"[green]✓[/green] Created variable: {key}")
+
+
+@var_app.command("remove")
+@handle_cli_errors
+def var_remove(
+    ctx: typer.Context,
+    workspace: Annotated[
+        str | None,
+        typer.Argument(
+            help="Workspace name (auto-detected from terraform.tf if in terraform directory)"
+        ),
+    ] = None,
+    key: Annotated[str | None, typer.Argument(help="Variable key to remove")] = None,
+    organization: Annotated[
+        str | None,
+        typer.Option(
+            "--organization",
+            "-o",
+            help="TFC organization (auto-detected from context if available)",
+        ),
+    ] = None,
+    force: Annotated[bool, typer.Option("--force", "-f", help="Skip confirmation")] = False,
+):
+    """Remove a workspace variable."""
+    if key is None:
+        console.print("[red]Error: Variable key is required.[/red]")
+        raise typer.Exit(1)
+
+    org, ws_name = validate_context(organization, workspace, require_workspace=True)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(cast(str, ws_name), org)
+        variables: list[WorkspaceVariable] = client.workspaces.get_variables(ws.id) or []
+        existing_var = next((v for v in variables if v.key == key), None)
+
+        if not existing_var:
+            console.print(f"[yellow]Variable '{key}' not found in workspace '{ws_name}'[/yellow]")
+            raise typer.Exit(1)
+
+        if not force and not typer.confirm(f"Remove variable '{key}' from workspace '{ws_name}'?"):
+            console.print("[yellow]Aborted.[/yellow]")
+            raise typer.Exit(0)
+
+        client.workspaces.delete_variable(workspace_id=ws.id, variable_id=existing_var.id)
+        console.print(f"[green]✓[/green] Removed variable: {key}")
+
+
+@var_app.command("copy")
+@handle_cli_errors
+def var_copy(
+    ctx: typer.Context,
+    source: str = typer.Argument(..., help="Source workspace name"),
+    target: str = typer.Argument(..., help="Target workspace name"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+    overwrite: bool = typer.Option(False, "--overwrite", help="Overwrite existing variables"),
+):
+    """Copy all variables from one workspace to another."""
+    org, _ = validate_context(organization)
+
+    with get_client(ctx, organization=org) as client:
+        ws_source = client.workspaces.get(source, org)
+        ws_target = client.workspaces.get(target, org)
+
+        source_variables: list[WorkspaceVariable] = (
+            client.workspaces.get_variables(ws_source.id) or []
+        )
+        target_variables: list[WorkspaceVariable] = (
+            client.workspaces.get_variables(ws_target.id) or []
+        )
+
+        target_keys = {v.key for v in target_variables}
+
+        console.print(f"[dim]Copying {len(source_variables)} variables: {source} → {target}[/dim]")
+
+        copied = 0
+        skipped = 0
+        updated = 0
+
+        for var in source_variables:
+            if var.key in target_keys:
+                if overwrite:
+                    t_v = next(v for v in target_variables if v.key == var.key)
+                    client.workspaces.update_variable(
+                        variable_id=t_v.id,
+                        value=var.value,
+                        hcl=var.hcl,
+                        sensitive=var.sensitive,
+                        description=var.description,
+                    )
+                    updated += 1
+                else:
+                    skipped += 1
+                    continue
+            else:
+                client.workspaces.create_variable(
+                    workspace_id=ws_target.id,
+                    key=var.key,
+                    value=var.value or "",
+                    category=var.category,
+                    hcl=var.hcl,
+                    sensitive=var.sensitive,
+                    description=var.description,
+                )
+                copied += 1
+
+        console.print(
+            f"[green]✓[/green] Done! {copied} created, {updated} updated, {skipped} skipped."
+        )

--- a/tests/features/workspace_var.feature
+++ b/tests/features/workspace_var.feature
@@ -1,0 +1,39 @@
+Feature: Workspace Variable Subgroup
+  As a Terraform Cloud user
+  I want to manage workspace variables through a unified subcommand group
+  So that variable operations are consistently grouped under "workspace var"
+
+  Scenario: List variables for a workspace
+    Given workspace "my-app-dev" has variables configured
+    When I list variables for workspace "my-app-dev"
+    Then I should see the variable listing
+    And exit code should be 0
+
+  Scenario: Set a new variable in a workspace
+    Given workspace "my-app-dev" exists with no existing variables
+    When I set variable "region" to "us-east-1" in workspace "my-app-dev"
+    Then the variable should be created
+    And output should confirm "Created variable: region"
+    And exit code should be 0
+
+  Scenario: Update an existing variable in a workspace
+    Given workspace "my-app-dev" has variable "region" set to "us-west-2"
+    When I set variable "region" to "eu-west-1" in workspace "my-app-dev"
+    Then the variable should be updated
+    And output should confirm "Updated variable: region"
+    And exit code should be 0
+
+  Scenario: Remove a variable from a workspace with force flag
+    Given workspace "my-app-dev" has variable "old-var" configured
+    When I remove variable "old-var" from workspace "my-app-dev" with --force
+    Then the variable should be deleted
+    And output should confirm "Removed variable: old-var"
+    And exit code should be 0
+
+  Scenario: Copy variables between workspaces
+    Given workspace "prod-app" has 2 variables
+    And workspace "staging-app" has no variables
+    When I copy variables from "prod-app" to "staging-app"
+    Then 2 variables should be created in "staging-app"
+    And output should confirm variables were copied
+    And exit code should be 0

--- a/tests/test_cli/test_workspace_var_bdd.py
+++ b/tests/test_cli/test_workspace_var_bdd.py
@@ -1,0 +1,266 @@
+"""BDD step definitions for workspace var subgroup commands."""
+
+from unittest.mock import Mock, patch
+
+from pytest_bdd import given, scenarios, then, when
+from typer.testing import CliRunner
+
+from terrapyne.cli.main import app
+from terrapyne.models.variable import WorkspaceVariable
+from terrapyne.models.workspace import Workspace
+
+scenarios("../features/workspace_var.feature")
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_workspace(name="my-app-dev", ws_id="ws-001"):
+    ws = Mock(spec=Workspace)
+    ws.id = ws_id
+    ws.name = name
+    return ws
+
+
+def _make_var(key, value="val", var_id="var-001", category="terraform"):
+    return WorkspaceVariable(
+        id=var_id,
+        key=key,
+        value=value,
+        category=category,
+        hcl=False,
+        sensitive=False,
+        description=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Givens
+# ---------------------------------------------------------------------------
+
+
+@given('workspace "my-app-dev" has variables configured', target_fixture="mock_client")
+def ws_has_variables():
+    client = Mock()
+    ws = _make_workspace()
+    client.workspaces.get.return_value = ws
+    client.workspaces.get_variables.return_value = [
+        _make_var("region", "us-east-1"),
+        _make_var("env", "production", var_id="var-002"),
+    ]
+    return client
+
+
+@given('workspace "my-app-dev" exists with no existing variables', target_fixture="mock_client")
+def ws_no_variables():
+    client = Mock()
+    ws = _make_workspace()
+    client.workspaces.get.return_value = ws
+    client.workspaces.get_variables.return_value = []
+    client.workspaces.create_variable.return_value = _make_var("region", "us-east-1")
+    return client
+
+
+@given(
+    'workspace "my-app-dev" has variable "region" set to "us-west-2"', target_fixture="mock_client"
+)
+def ws_has_region_variable():
+    client = Mock()
+    ws = _make_workspace()
+    client.workspaces.get.return_value = ws
+    client.workspaces.get_variables.return_value = [_make_var("region", "us-west-2")]
+    return client
+
+
+@given('workspace "my-app-dev" has variable "old-var" configured', target_fixture="mock_client")
+def ws_has_old_var():
+    client = Mock()
+    ws = _make_workspace()
+    client.workspaces.get.return_value = ws
+    client.workspaces.get_variables.return_value = [_make_var("old-var", "some-value")]
+    return client
+
+
+@given('workspace "prod-app" has 2 variables', target_fixture="mock_client")
+def prod_has_two_vars():
+    client = Mock()
+    prod_ws = _make_workspace("prod-app", "ws-prod")
+    staging_ws = _make_workspace("staging-app", "ws-staging")
+
+    def get_ws(name, org):
+        return prod_ws if name == "prod-app" else staging_ws
+
+    client.workspaces.get.side_effect = get_ws
+    client.workspaces.get_variables.side_effect = lambda ws_id: (
+        [_make_var("region", "us-east-1"), _make_var("env", "prod", var_id="var-002")]
+        if ws_id == "ws-prod"
+        else []
+    )
+    client.workspaces.create_variable.return_value = None
+    return client
+
+
+@given('workspace "staging-app" has no variables')
+def staging_no_vars():
+    """Already handled in the prod fixture via side_effect."""
+
+
+# ---------------------------------------------------------------------------
+# Whens
+# ---------------------------------------------------------------------------
+
+
+@when('I list variables for workspace "my-app-dev"', target_fixture="cli_result")
+def list_vars(mock_client):
+    with (
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("terrapyne.cli.context_helpers.validate_context") as v,
+    ):
+        v.return_value = ("test-org", "my-app-dev")
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(app, ["workspace", "var", "list", "my-app-dev", "-o", "test-org"])
+
+
+@when(
+    'I set variable "region" to "us-east-1" in workspace "my-app-dev"', target_fixture="cli_result"
+)
+def set_new_var(mock_client):
+    with (
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("terrapyne.cli.context_helpers.validate_context") as v,
+    ):
+        v.return_value = ("test-org", "my-app-dev")
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(
+            app,
+            [
+                "workspace",
+                "var",
+                "set",
+                "my-app-dev",
+                "--key",
+                "region",
+                "--value",
+                "us-east-1",
+                "-o",
+                "test-org",
+            ],
+        )
+
+
+@when(
+    'I set variable "region" to "eu-west-1" in workspace "my-app-dev"', target_fixture="cli_result"
+)
+def set_existing_var(mock_client):
+    with (
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("terrapyne.cli.context_helpers.validate_context") as v,
+    ):
+        v.return_value = ("test-org", "my-app-dev")
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(
+            app,
+            [
+                "workspace",
+                "var",
+                "set",
+                "my-app-dev",
+                "--key",
+                "region",
+                "--value",
+                "eu-west-1",
+                "-o",
+                "test-org",
+            ],
+        )
+
+
+@when(
+    'I remove variable "old-var" from workspace "my-app-dev" with --force',
+    target_fixture="cli_result",
+)
+def remove_var_with_force(mock_client):
+    with (
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("terrapyne.cli.context_helpers.validate_context") as v,
+    ):
+        v.return_value = ("test-org", "my-app-dev")
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(
+            app,
+            ["workspace", "var", "remove", "my-app-dev", "old-var", "-o", "test-org", "--force"],
+        )
+
+
+@when('I copy variables from "prod-app" to "staging-app"', target_fixture="cli_result")
+def copy_vars(mock_client):
+    with (
+        patch("terrapyne.api.client.TFCClient") as c,
+        patch("terrapyne.cli.context_helpers.validate_context") as v,
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+        return runner.invoke(
+            app,
+            ["workspace", "var", "copy", "prod-app", "staging-app", "-o", "test-org"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Thens
+# ---------------------------------------------------------------------------
+
+
+@then("I should see the variable listing")
+def check_variable_listing(cli_result):
+    assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"
+
+
+@then("the variable should be created")
+def check_var_created(cli_result):
+    assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"
+
+
+@then('output should confirm "Created variable: region"')
+def check_created_output(cli_result):
+    assert "Created variable: region" in cli_result.stdout
+
+
+@then("the variable should be updated")
+def check_var_updated(cli_result):
+    assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"
+
+
+@then('output should confirm "Updated variable: region"')
+def check_updated_output(cli_result):
+    assert "Updated variable: region" in cli_result.stdout
+
+
+@then("the variable should be deleted")
+def check_var_deleted(cli_result):
+    assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"
+
+
+@then('output should confirm "Removed variable: old-var"')
+def check_removed_output(cli_result):
+    assert "Removed variable: old-var" in cli_result.stdout
+
+
+@then('2 variables should be created in "staging-app"')
+def check_vars_copied(cli_result, mock_client):
+    assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"
+    assert mock_client.workspaces.create_variable.call_count == 2
+
+
+@then("output should confirm variables were copied")
+def check_copy_output(cli_result):
+    assert "Done!" in cli_result.stdout
+
+
+@then("exit code should be 0")
+def exit_0(cli_result):
+    assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"

--- a/tests/test_cli/test_workspace_var_bdd.py
+++ b/tests/test_cli/test_workspace_var_bdd.py
@@ -104,9 +104,10 @@ def prod_has_two_vars():
     return client
 
 
-@given('workspace "staging-app" has no variables')
-def staging_no_vars():
-    """Already handled in the prod fixture via side_effect."""
+@given('workspace "staging-app" has no variables', target_fixture="mock_client")
+def staging_no_vars(mock_client):
+    """staging-app's empty variables already handled in prod_has_two_vars via side_effect."""
+    return mock_client
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +219,10 @@ def copy_vars(mock_client):
 @then("I should see the variable listing")
 def check_variable_listing(cli_result):
     assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"
+    assert "region" in cli_result.stdout, (
+        f"Expected variable key 'region' in output: {cli_result.stdout}"
+    )
+    assert "env" in cli_result.stdout, f"Expected variable key 'env' in output: {cli_result.stdout}"
 
 
 @then("the variable should be created")
@@ -241,8 +246,9 @@ def check_updated_output(cli_result):
 
 
 @then("the variable should be deleted")
-def check_var_deleted(cli_result):
+def check_var_deleted(cli_result, mock_client):
     assert cli_result.exit_code == 0, f"Exit {cli_result.exit_code}: {cli_result.stdout}"
+    mock_client.workspaces.delete_variable.assert_called_once()
 
 
 @then('output should confirm "Removed variable: old-var"')


### PR DESCRIPTION
## Summary

- **A18**: Refactors fragmented `workspace var-set/var-rm/var-copy/variables` commands into a unified `workspace var set/remove/copy/list` subgroup. Legacy commands are kept as thin delegating aliases for backward compatibility.
- **D10**: Syncs `cli-reference.md` — adds `workspace var`, `workspace create/delete`, `workspace triggers`, `varset`, `vcs list`; removes non-existent `vcs update-branch`.

## Test plan

- [x] BDD scenarios written first (RED), then implementation (GREEN), then refactored
- [x] Adversarial review (Bart) found 4 criticals — all fixed before merge
- [x] 788 tests pass, 84.38% coverage (up from 83%)
- [x] Legacy commands verified to delegate to new subgroup (single source of truth)
- [x] `delete_variable` API call asserted in remove scenario
- [x] Variable keys asserted in listing output