### PR TITLE
feat(ax): Add Agent Experience (AX) CLI primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,20 +11,15 @@ uv run ruff check . && uv run ruff format .  # Lint and format
 uv run mypy src/                # Type check
 ```
 
-## Core Principles
+## Detailed Agent Guidelines
 
-- **Red/Green TDD**: Write failing tests first, minimal implementation, then refactor
-- **Adzic BDD**: Feature files use Gojko Adzic's Specification by Example (outcome-focused, not implementation-scripted)
-- **Atomic Commits (ACP)**: Every commit is a single, self-contained unit of verified work — one reason to change, all tests green, linting and type checks pass. Never batch unrelated changes. Never commit broken state.
-- **No AI Markers**: Never add co-author or AI attribution to code, commits, docs, or PR descriptions
+This file uses progressive disclosure. For detailed instructions on how agents should operate within this codebase, please refer to the following critical guides:
 
-## Development Guides
-
-Detailed conventions and patterns:
-- [Python & Testing](docs/how-to/python-and-testing.md) — Type hints, imports, test structure, pytest-bdd
-- [BDD Specifications](docs/explanation/bdd-specifications.md) — Writing Adzic-aligned feature files and step definitions
-- [Commits & Review](docs/how-to/commits-and-review.md) — Atomic commits, conventional format, PR process
-- [Architecture](docs/explanation/architecture/) — ADRs, design decisions, model patterns
+- **[Agent Workflow Guide](file:///home/unop/shalomb/terrapyne/docs/how-to/agent-workflow.md)** — **CRITICAL**: The strict BDD/TDD Red-Green-Refactor cycle, ACP commit protocol, and mandatory Adversarial Review (Bart) rules.
+- **[Python & Testing](file:///home/unop/shalomb/terrapyne/docs/how-to/python-and-testing.md)** — Type hints, imports, test structure, pytest-bdd patterns.
+- **[BDD Specifications](file:///home/unop/shalomb/terrapyne/docs/explanation/bdd-specifications.md)** — Writing Adzic-aligned feature files and step definitions.
+- **[Commits & Review](file:///home/unop/shalomb/terrapyne/docs/how-to/commits-and-review.md)** — Atomic commits, conventional format, PR process.
+- **[Architecture](file:///home/unop/shalomb/terrapyne/docs/explanation/architecture/)** — ADRs, design decisions, model patterns.
 
 ## Essential Skills
 
@@ -38,138 +33,3 @@ Use these skills to stay aligned:
 | [test-accordion](~/.claude/skills/test-accordion/) | Expanding/contracting test scope in elastic loop during TDD |
 | [using-git-worktrees](~/.claude/skills/using-git-worktrees/) | Creating isolated feature branches with worktrees |
 | [commit](~/.claude/skills/commit/) | Crafting atomic, verified commits before pushing |
-
-## Project Structure
-
-```
-src/terrapyne/
-├── cli/          # Typer CLI commands (workspace, run, state, project, etc.)
-├── api/          # TFCClient and API abstractions
-├── models/       # Pydantic models (Run, Workspace, StateVersion, etc.)
-├── core/         # Parsing and core utilities
-└── sdk/          # High-level SDK interface
-
-tests/
-├── test_cli/     # pytest-bdd step definitions and assertions
-├── test_unit/    # Unit tests for models and utilities
-├── features/     # Gherkin feature files (.feature)
-└── conftest.py   # Shared fixtures
-```
-
-## Testing Patterns
-
-**BDD (pytest-bdd):**
-- Feature files describe business outcomes: `tests/features/*.feature`
-- Step definitions in `tests/test_cli/test_*_bdd.py`
-- Use `@given/@when/@then` decorators with parsers
-- Mock at TFCClient level, not httpx
-- Assert outcomes (e.g., "active run count visible"), not implementation (e.g., "emoji 🟢 present")
-
-**Unit Tests:**
-- Models and utilities in `tests/test_unit/`
-- Use fixtures and mocks (`Mock(spec=...)` for type safety)
-- Fast, deterministic, no I/O
-
-**Coverage:**
-- Minimum 65% across `src/terrapyne/`
-- Run: `pytest --cov=terrapyne --cov-report=html`
-
-## Code Quality
-
-**Ruff (linting & formatting):**
-```bash
-ruff check . && ruff format .
-```
-- Line length: 100 chars
-- Target: Python 3.12+
-- Rules: E, F, I, B, PL, RUF (see `pyproject.toml` for exceptions)
-
-**MyPy (type checking):**
-```bash
-mypy src/
-```
-- Strict mode enabled where possible
-- Document any `# type: ignore` with reason
-
-**Pre-commit hooks:**
-- Ruff, MyPy, and test coverage validation run automatically
-- Fix issues before pushing
-
-## Commits & PRs
-
-Atomic Commit Protocol (ACP) — **mandatory, not optional**:
-
-1. **One reason to change** — each commit addresses exactly one concern (feature slice, bug fix, doc update, refactor). Split work before committing, never after.
-2. **Verified before commit** — the full verification suite must pass locally:
-   ```bash
-   uv run pytest tests/ --ignore=tests/uat -x -q --no-header --cov=src --cov-report=term
-   uv run ruff check src/ tests/
-   uv run mypy src/
-   ```
-3. **Conventional Commits format** — `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:` — message describes *why*, not *what*
-4. **No AI markers** — no co-author lines, no AI attribution anywhere
-5. **Use `/commit` skill** — always use the commit skill to stage, verify, and craft the message
-
-A commit that breaks tests, bundles unrelated changes, or skips verification is a protocol violation. Revert it.
-
-See [Commits & Review Guide](docs/how-to/commits-and-review.md) for details.
-
-## Development Workflow
-
-1. Create a worktree for isolated work:
-   ```bash
-   # Skill: using-git-worktrees
-   git worktree add .claude/worktrees/feature-name
-   ```
-
-2. Write failing test first (Red):
-   - Feature file (BDD) or test function (unit)
-   - Use `pytest -k <test>` to focus
-
-3. Make test pass (Green):
-   - Minimal implementation, no over-engineering
-   - Run tests frequently: `pytest --tb=short`
-   - Use `test-accordion` skill to expand/contract scope
-
-4. Refactor (optional):
-   - Only if code clarity improves
-   - Re-run tests; ensure coverage stable
-
-5. Verify — full suite must be green before committing:
-   ```bash
-   uv run pytest tests/ --ignore=tests/uat -x -q --no-header --cov=src --cov-report=term
-   uv run ruff check src/ tests/
-   uv run mypy src/
-   ```
-
-6. Commit & push (ACP — see Commits & PRs section):
-   - Use `/commit` skill — mandatory, runs verification before committing
-   - Push branch before opening PR: `git push -u origin <branch>`
-   - Open PR: `gh pr create --title "..." --body "..." --base main`
-   - Fill in every section of `.github/PULL_REQUEST_TEMPLATE.md` in the PR body
-
-7. Review & merge (Bart):
-   - Bart reviews the PR adversarially
-   - No critical issues → Bart merges: `gh pr merge <number> --squash --delete-branch`
-   - Critical issues found → Bart writes them back as a new task list; Ralph resumes a new iteration
-   - Ensure no AI markers in code/commits
-
-## Continuous Integration
-
-**Pre-commit checks:**
-- Ruff (linting, formatting)
-- MyPy (type checking)
-- Test coverage (≥65%)
-
-**All commits must pass locally before pushing** — no fix-up commits.
-
-## Getting Help
-
-- Architecture decisions: See `docs/explanation/architecture/ADR-*.md`
-- Testing strategy: See ADR-004 and [BDD Specifications guide](docs/explanation/bdd-specifications.md)
-- Python patterns: See [Python & Testing guide](docs/how-to/python-and-testing.md)
-- Git safety: Use `/git` skill before any operation
-
----
-
-**Note:** This project enforces clean code and lean principles. Challenge vague requirements; propose alternatives before implementing. No speculative features.

--- a/TODO.md
+++ b/TODO.md
@@ -26,9 +26,9 @@ For evaluating live TFC behaviour, use:
 
 Based on recent Agent-Native CLI design research, the backlog is currently structured into the following upcoming PR Batches:
 
-- **PR Batch 3: The Agent Experience (AX) Core**
+- **PR Batch 3: The Agent Experience (AX) Core** *(In Progress — feat/ax-core)*
   Focus: Eliminating agent "glue logic" (bash pipes, jq, polling loops).
-  Includes: AX5 (JSON output for mutations), AX6 (Idempotence flags), AX3 (Trigger & Wait), AX1 (Universal ID Resolver).
+  Includes: AX1 ✅, AX2 ✅, AX3 ✅, AX4 ✅, AX5 ✅, AX6 ✅.
 
 - **PR Batch 4: Scripting & Automation Polish**
   Focus: Fixing bugs that break non-interactive shell scripting and automation pipelines.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,9 @@
 # TODO — Terrapyne Product Backlog
 
+> [!IMPORTANT]
+> **AGENTS**: Before pulling tasks from this backlog or writing any code, you MUST read `AGENTS.md` and strictly follow the TDD/BDD Adzic/Farley rules, ACP commit protocol, and the Adversarial Review (Bart) workflow.
+
+
 Bugs, gaps, and improvements. Sources:
 - Exploratory testing against live TFC
 - Product fitness appraisal against TFC API model (April 2026)

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,24 @@ For evaluating live TFC behaviour, use:
 
 ---
 
+## Iteration Plan (May 2026)
+
+Based on recent Agent-Native CLI design research, the backlog is currently structured into the following upcoming PR Batches:
+
+- **PR Batch 3: The Agent Experience (AX) Core**
+  Focus: Eliminating agent "glue logic" (bash pipes, jq, polling loops).
+  Includes: AX5 (JSON output for mutations), AX6 (Idempotence flags), AX3 (Trigger & Wait), AX1 (Universal ID Resolver).
+
+- **PR Batch 4: Scripting & Automation Polish**
+  Focus: Fixing bugs that break non-interactive shell scripting and automation pipelines.
+  Includes: B13 (exit code), B14 (missing --yes), B12 (truncation), B9 (name lookup bug), B15 (flag position).
+
+- **PR Batch 5: CLI Surface Refactoring & Security**
+  Focus: Paying down technical debt, improving consistency, and patching data leaks.
+  Includes: A18 (var command refactor), A16 (sensitive leak), D10 (docs).
+
+---
+
 ## Priority Matrix (WSJF)
 
 **Impact**: 🔴 High (4), 🟡 Medium (2), 🟢 Low (1)

--- a/docs/how-to/agent-workflow.md
+++ b/docs/how-to/agent-workflow.md
@@ -1,0 +1,69 @@
+# Agent Workflow Guide
+
+This guide dictates the mandatory workflow, testing practices, and review steps for all AI agents (e.g., Marge, Ralph, Bart, etc.) operating in the Terrapyne repository.
+
+## Strict BDD and TDD Adherence
+
+All features and changes must be built using strict **Adzic BDD (Behavior-Driven Development)** and **Farley TDD (Test-Driven Development)**.
+
+### The Double-Loop Workflow
+
+1. **Outer Loop (Red BDD)**: Write a failing scenario in `tests/features/*.feature` using Gojko Adzic's Specification by Example principles (outcome-focused, not implementation-scripted).
+2. **Inner Loop (Red TDD)**: Write a failing unit test for the supporting model/API in `tests/test_unit/`.
+3. **Green TDD**: Write the minimal code to make the unit test pass. Run tests frequently.
+4. **Safe ACP Commit**: Once the tests are green, perform an Atomic Commit Protocol (ACP) commit. **Do NOT refactor the messy "Green" state before committing.**
+5. **Refactor & Commit**: Refactor the code for clarity, ensure all tests still pass, and then make a second commit containing the clean refactored state. This 2-commit "Green then Refactor" cycle is essential.
+6. **Green BDD**: Implement the CLI wrapper/logic to make the outer loop scenario pass.
+
+*Use the `test-accordion` skill to expand and contract test scope during this elastic loop.*
+
+## The Adversarial Review (Bart)
+
+Once the implementation is complete and committed:
+
+1. The change MUST be subjected to an adversarial review by **Bart** (the review agent).
+2. Use the `bart` skill to review the code, diff, test output, or PR.
+3. **Fixing Issues**: The main agent must fix all *related* issues found by Bart. 
+4. **Parking Issues**: Any *unrelated* bugs, smells, or edge cases found by Bart during the review must not be bundled into the current commit/PR. Instead, they must be parked back onto the `TODO.md` backlog for a future iteration.
+
+## Commit Protocol (ACP)
+
+Atomic Commit Protocol (ACP) is **mandatory, not optional**:
+
+1. **One reason to change** — each commit addresses exactly one concern. Split work before committing.
+2. **Verified before commit** — the full verification suite must pass locally:
+   ```bash
+   uv run pytest tests/ --ignore=tests/uat -x -q --no-header --cov=src --cov-report=term
+   uv run ruff check src/ tests/
+   uv run mypy src/
+   ```
+3. **Conventional Commits format** — `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`.
+4. **No AI markers** — no co-author lines, no AI attribution anywhere.
+5. **Use `/commit` skill** — always use the commit skill to stage, verify, and craft the message.
+
+## Development Worktrees
+
+Always isolate your work. Before beginning an implementation plan:
+1. Create a worktree for isolated work using the `using-git-worktrees` skill.
+   ```bash
+   git worktree add .claude/worktrees/feature-name
+   ```
+
+## Continuous Integration
+
+**Pre-commit checks:**
+- Ruff (linting, formatting)
+- MyPy (type checking)
+- Test coverage (≥65%)
+
+**All commits must pass locally before pushing** — no fix-up commits.
+
+## Getting Help
+
+- Architecture decisions: See `docs/explanation/architecture/ADR-*.md`
+- Testing strategy: See `docs/explanation/architecture/ADR-004-workspace-dashboard-testing.md` and `docs/explanation/bdd-specifications.md`
+- Python patterns: See `docs/how-to/python-and-testing.md`
+- Git safety: Use `/git` skill before any operation
+
+---
+**Note:** This project enforces clean code and lean principles. Challenge vague requirements; propose alternatives before implementing. No speculative features.

--- a/src/terrapyne/api/client.py
+++ b/src/terrapyne/api/client.py
@@ -203,7 +203,7 @@ class TFCClient:
                 ) from e
             if status_code == 404:
                 raise TFCNotFoundError(message, status_code=status_code, response=response) from e
-            if status_code == 409:
+            if status_code in (409, 422):
                 raise TFCConflictError(message, status_code=status_code, response=response) from e
             if status_code == 429:
                 raise TFCRateLimitError(message, status_code=status_code, response=response) from e

--- a/src/terrapyne/api/workspace_clone.py
+++ b/src/terrapyne/api/workspace_clone.py
@@ -721,6 +721,7 @@ class CloneWorkspaceAPI:
         # Return comprehensive result
         return {
             "status": "success",
+            "workspace": target_ws,
             "source_workspace_id": source_ws.id,
             "source_workspace_name": source_workspace_name,
             "target_workspace_id": target_workspace_id,

--- a/src/terrapyne/cli/project_cmd.py
+++ b/src/terrapyne/cli/project_cmd.py
@@ -25,6 +25,22 @@ def _show_help(ctx: typer.Context):
         console.print(ctx.get_help())
 
 
+@app.command("id")
+@handle_cli_errors
+def project_id(
+    ctx: typer.Context,
+    project_name: str = typer.Argument(..., help="Project name"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+) -> None:
+    """Print the raw project ID (prj-*) to stdout — no formatting."""
+    from terrapyne.cli.context_helpers import validate_context
+
+    org, _ = validate_context(organization)
+    with get_client(ctx, organization=org) as client:
+        project = client.projects.get_by_name(project_name, org)
+    print(project.id)
+
+
 @app.command("list")
 @handle_cli_errors
 def project_list(

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -87,7 +87,7 @@ def run_list(
 @handle_cli_errors
 def run_show(
     ctx: typer.Context,
-    run_id: Annotated[str, typer.Argument(help="Run ID (e.g., run-xxx)")],
+    run_id: Annotated[str | None, typer.Argument(help="Run ID (e.g., run-xxx)")] = None,
     organization: Annotated[
         str | None,
         typer.Option(
@@ -96,14 +96,37 @@ def run_show(
             help="TFC organization (auto-detected from context if available)",
         ),
     ] = None,
+    workspace: Annotated[
+        str | None,
+        typer.Option("--workspace", "-w", help="Workspace name (required with --latest)"),
+    ] = None,
+    latest: Annotated[
+        bool,
+        typer.Option("--latest", help="Show the most recent run for --workspace"),
+    ] = False,
     output_format: Annotated[
         str, typer.Option("--format", "-f", help="Output format (table, json)")
     ] = "table",
 ):
     """Show details for a specific run."""
-    org, _ = validate_context(organization)
+    org, ws_name = validate_context(organization, workspace)
 
     with get_client(ctx, organization=org) as client:
+        if latest:
+            if not ws_name:
+                console.print("[red]Error: --latest requires --workspace[/red]")
+                raise typer.Exit(1)
+            ws = client.workspaces.get(ws_name, org)
+            runs, _ = client.runs.list(workspace_id=ws.id, limit=1)
+            run = next(iter(runs), None)
+            if not run:
+                console.print("[yellow]No runs found for workspace.[/yellow]")
+                raise typer.Exit(0)
+            run_id = run.id
+        elif not run_id:
+            console.print("[red]Error: Provide a run ID or use --workspace with --latest[/red]")
+            raise typer.Exit(1)
+
         # Fetch run details
         run = client.runs.get(run_id)
 
@@ -213,7 +236,7 @@ def run_plan(
 @handle_cli_errors
 def run_logs(
     ctx: typer.Context,
-    run_id: Annotated[str, typer.Argument(help="Run ID")],
+    run_id: Annotated[str | None, typer.Argument(help="Run ID")] = None,
     organization: Annotated[
         str | None,
         typer.Option(
@@ -222,15 +245,38 @@ def run_logs(
             help="TFC organization (auto-detected from context if available)",
         ),
     ] = None,
+    workspace: Annotated[
+        str | None,
+        typer.Option("--workspace", "-w", help="Workspace name (required with --latest)"),
+    ] = None,
+    latest: Annotated[
+        bool,
+        typer.Option("--latest", help="Show logs for the most recent run of --workspace"),
+    ] = False,
     stage: Annotated[
         str,
         typer.Option("--stage", help="Logs to show: plan, apply"),
     ] = "plan",
 ):
     """Show logs for a specific run stage."""
-    org, _ = validate_context(organization)
+    org, ws_name = validate_context(organization, workspace)
 
     with get_client(ctx, organization=org) as client:
+        if latest:
+            if not ws_name:
+                console.print("[red]Error: --latest requires --workspace[/red]")
+                raise typer.Exit(1)
+            ws = client.workspaces.get(ws_name, org)
+            runs, _ = client.runs.list(workspace_id=ws.id, limit=1)
+            run = next(iter(runs), None)
+            if not run:
+                console.print("[yellow]No runs found for workspace.[/yellow]")
+                raise typer.Exit(0)
+            run_id = run.id
+        elif not run_id:
+            console.print("[red]Error: Provide a run ID or use --workspace with --latest[/red]")
+            raise typer.Exit(1)
+
         run = client.runs.get(run_id)
 
         if stage == "plan":
@@ -480,8 +526,8 @@ def run_trigger(
     ] = None,
     wait: Annotated[
         bool,
-        typer.Option("--wait/--no-wait", help="Wait for completion"),
-    ] = True,
+        typer.Option("--wait/--no-wait", help="Wait for completion (default: no-wait)"),
+    ] = False,
     wait_queue: Annotated[
         bool,
         typer.Option("--wait-queue", help="If another run is active, wait for it to finish"),
@@ -513,6 +559,10 @@ def run_trigger(
             ),
         ),
     ] = False,
+    output_format: Annotated[
+        str,
+        typer.Option("--format", "-f", help="Output format: table, json"),
+    ] = "table",
 ):
     """Trigger a new run with advanced queue management."""
     # Resolve organization and workspace
@@ -564,10 +614,11 @@ def run_trigger(
         if not speculative and replace:
             run_type = f"REPLACE {run_type}"
 
-        console.print(
-            f"[dim]Triggering [bold cyan]{run_type}[/bold cyan] run for workspace:[/dim] "
-            f"{workspace_name}"
-        )
+        if output_format != "json":
+            console.print(
+                f"[dim]Triggering [bold cyan]{run_type}[/bold cyan] run for workspace:[/dim] "
+                f"{workspace_name}"
+            )
 
         # 2. Create run
         if speculative:
@@ -586,6 +637,13 @@ def run_trigger(
                 refresh_only=refresh_only,
                 debug=debug_run,
             )
+
+        if output_format == "json":
+            from terrapyne.cli.output_helpers import emit_json as _emit_json
+
+            _emit_json(run.model_dump())
+            if not wait:
+                return
 
         console.print(f"[green]✓[/green] Created {run_type} run: {run.id}")
         if message:

--- a/src/terrapyne/cli/state_cmd.py
+++ b/src/terrapyne/cli/state_cmd.py
@@ -255,3 +255,44 @@ def state_outputs(
         table.add_row(o.name, o.type, val)
 
     console.print(table)
+
+
+@app.command("output")
+def state_output(
+    ctx: typer.Context,
+    workspace: str = typer.Argument(..., help="Workspace name or ID (ws-*)"),
+    name: str = typer.Argument(..., help="Output name to extract"),
+    organization: str | None = typer.Option(None, "-o", "--organization"),
+) -> None:
+    """Print a single state output value — raw, no formatting.
+
+    Equivalent to: tfc state outputs <workspace> <name> --raw
+
+    Example:
+        VPC_ID=$(tfc state output my-workspace vpc_id)
+    """
+    org, _ = validate_context(organization)
+
+    with get_client(ctx, organization=org) as client:
+        if workspace.startswith("ws-"):
+            ws = client.workspaces.get_by_id(workspace)
+        else:
+            ws = client.workspaces.get(workspace, org)
+        sv = client.state_versions.get_current(ws.id)
+        outputs = client.state_versions.list_outputs(sv.id)
+
+    output = next((o for o in outputs if o.name == name), None)
+    if not output:
+        error_console.print(f"[red]Error: Output '{name}' not found.[/red]")
+        raise typer.Exit(1)
+
+    if output.sensitive:
+        error_console.print(
+            "[yellow]Error: Output is sensitive — use 'state outputs' with appropriate access[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    if isinstance(output.value, (dict, list)):
+        print(json.dumps(output.value))
+    else:
+        print(str(output.value))

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -83,6 +83,20 @@ def workspace_list(
             )
 
 
+@app.command("id")
+@handle_cli_errors
+def workspace_id(
+    ctx: typer.Context,
+    workspace: str = typer.Argument(..., help="Workspace name"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+) -> None:
+    """Print the raw workspace ID (ws-*) to stdout — no formatting."""
+    org = resolve_organization(organization)
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(workspace, organization=org)
+    print(ws.id)
+
+
 @app.command("show")
 @handle_cli_errors
 def workspace_show(
@@ -428,6 +442,7 @@ def workspace_clone(
         "-p",
         help="Project ID to assign the cloned workspace to (overrides source project)",
     ),
+    output_format: str = typer.Option("table", "--format", help="Output format: table, json"),
 ):
     """Clone a workspace (configuration and variables).
 
@@ -443,7 +458,8 @@ def workspace_clone(
     """
     org, _ = validate_context(organization)
 
-    console.print(f"\n[dim]Cloning workspace:[/dim] {source} → {target}")
+    if output_format != "json":
+        console.print(f"\n[dim]Cloning workspace:[/dim] {source} → {target}")
 
     with get_client(ctx, organization=org) as client:
         from terrapyne.api.workspace_clone import (
@@ -465,11 +481,16 @@ def workspace_clone(
                 project_id=project_id,
             )
 
-            console.print(f"\n[green]✓[/green] {result.get('message', 'Successfully cloned')}")
-
             if result.get("status") == "error":
                 console.print(f"[red]Error:[/red] {result.get('error', 'Unknown error')}")
                 raise typer.Exit(1)
+
+            new_ws = result.get("workspace")
+            if output_format == "json" and new_ws is not None:
+                emit_json(new_ws.model_dump())
+                return
+
+            console.print(f"\n[green]✓[/green] {result.get('message', 'Successfully cloned')}")
 
             # Show details of what was cloned
             res = result.get("results", {})
@@ -524,6 +545,10 @@ def workspace_create(
     oauth_token_id: str | None = typer.Option(
         None, "--oauth-token-id", help="OAuth token ID for VCS connection"
     ),
+    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table, json"),
+    ignore_exists: bool = typer.Option(
+        False, "--ignore-exists", help="Exit 0 if workspace already exists (idempotent)"
+    ),
 ):
     """Create a new workspace.
 
@@ -531,12 +556,14 @@ def workspace_create(
         # Create a basic workspace
         tfc workspace create my-new-workspace --organization my-org
 
-        # Create with specific Terraform version and execution mode
-        tfc workspace create my-new-workspace --tf-version 1.9.0 --execution-mode remote
+        # Capture the new workspace ID in a script
+        WS_ID=$(tfc workspace create my-new-workspace --format json | jq -r .id)
 
-        # Create with VCS connection
-        tfc workspace create my-new-workspace --vcs-repo org/repo --oauth-token-id ot-abc123
+        # Idempotent create — safe to retry
+        tfc workspace create my-new-workspace --ignore-exists
     """
+    from terrapyne.core.exceptions import TFCConflictError
+
     org = resolve_organization(organization)
     if not org:
         console.print("[red]Error: Organization not specified and not found in context.[/red]")
@@ -552,15 +579,29 @@ def workspace_create(
             vcs_repo_config["working-directory"] = working_dir
 
     with get_client(ctx, organization=org) as client:
-        ws = client.workspaces.create(
-            name=name,
-            organization=org,
-            project_id=project,
-            terraform_version=tf_version,
-            execution_mode=execution_mode,
-            working_directory=working_dir if not vcs_repo else None,
-            vcs_repo=vcs_repo_config,
-        )
+        try:
+            ws = client.workspaces.create(
+                name=name,
+                organization=org,
+                project_id=project,
+                terraform_version=tf_version,
+                execution_mode=execution_mode,
+                working_directory=working_dir if not vcs_repo else None,
+                vcs_repo=vcs_repo_config,
+            )
+        except TFCConflictError:
+            if ignore_exists:
+                ws = client.workspaces.get(name, organization=org)
+            else:
+                console.print(
+                    f"[red]Error: Workspace '{name}' already exists. "
+                    "Use --ignore-exists to return the existing workspace.[/red]"
+                )
+                raise typer.Exit(1) from None
+
+    if output_format == "json":
+        emit_json(ws.model_dump())
+        return
 
     console.print(f"[green]✓[/green] Created workspace: {ws.name}")
     if ws.terraform_version:

--- a/tests/features/agent_experience.feature
+++ b/tests/features/agent_experience.feature
@@ -1,0 +1,96 @@
+Feature: Agent Experience (AX) — Eliminating glue logic
+  As an AI coding agent orchestrating TFC workflows
+  I want first-class CLI primitives for common patterns
+  So I can avoid bash pipes, jq, and polling loops
+
+  Background:
+    Given a terraform cloud organization is accessible
+
+  # AX1 — Universal ID Resolver
+  Scenario: Resolve workspace ID without jq
+    Given a workspace "my-app-dev" exists
+    When I run "tfc workspace id my-app-dev"
+    Then stdout is exactly "ws-abc123"
+    And there is no extra formatting
+
+  Scenario: Resolve project ID without jq
+    Given a project "platform" exists with id "prj-xyz789"
+    When I run "tfc project id platform"
+    Then stdout is exactly "prj-xyz789"
+    And there is no extra formatting
+
+  Scenario: Resolving ID for a non-existent workspace exits non-zero
+    When I resolve the id of a workspace that does not exist
+    Then the exit code is 1
+    And stderr contains "not found"
+
+  # AX2 — Latest Run Lookups
+  Scenario: Show logs for the latest run without knowing its ID
+    Given a workspace "my-app-dev" has runs
+    When I run "tfc run logs --workspace my-app-dev --latest"
+    Then the logs for the most recent run are shown
+
+  Scenario: Show run detail for the latest run without knowing its ID
+    Given a workspace "my-app-dev" has a most recent run "run-latest-001"
+    When I run "tfc run show --workspace my-app-dev --latest"
+    Then the run detail for "run-latest-001" is shown
+
+  # AX3 — Trigger and Wait (silent, no log streaming)
+  Scenario: Trigger a run and wait silently for completion
+    Given a workspace "my-app-dev" is ready for operations
+    When I trigger a run for "my-app-dev" with "--wait"
+    Then the command blocks until the run reaches a terminal state
+    And no plan or apply logs are streamed
+    And the command exits with code 0 on success
+
+  Scenario: Trigger and wait exits non-zero when run errors
+    Given a workspace "my-app-dev" is ready for operations
+    When I trigger a run for "my-app-dev" with "--wait" and the run errors
+    Then the command exits with code 1
+
+  # AX4 — State Output Extraction
+  Scenario: Extract a single state output value
+    Given a workspace with output "vpc_id" = "vpc-0abc1234"
+    When I run "tfc state output my-app-dev vpc_id"
+    Then stdout is exactly "vpc-0abc1234"
+    And there is no table formatting
+
+  Scenario: Extracting a missing state output exits non-zero
+    Given a workspace with no output named "missing_key"
+    When I run "tfc state output my-app-dev missing_key"
+    Then the exit code is 1
+    And stderr contains "not found"
+
+  # AX5 — JSON output for mutation commands
+  Scenario: workspace create emits JSON with workspace ID
+    When I create workspace "my-new-ws" with "--format json"
+    Then stdout is valid JSON
+    And the JSON contains field "id" matching "ws-*"
+    And the JSON contains field "name" = "my-new-ws"
+
+  Scenario: workspace clone emits JSON with new workspace ID
+    Given a workspace "my-app-dev" exists
+    When I clone "my-app-dev" to "my-app-staging" with "--format json"
+    Then stdout is valid JSON
+    And the JSON contains field "id" matching "ws-*"
+    And the JSON contains field "name" = "my-app-staging"
+
+  Scenario: run trigger emits JSON with run ID
+    Given a workspace "my-app-dev" is ready for operations
+    When I trigger a run for "my-app-dev" with "--format json"
+    Then stdout is valid JSON
+    And the JSON contains field "id" matching "run-*"
+    And the JSON contains field "status"
+
+  # AX6 — Idempotent create
+  Scenario: workspace create with --ignore-exists succeeds when workspace already present
+    Given a workspace "my-app-dev" already exists
+    When I create workspace "my-app-dev" with "--ignore-exists"
+    Then the command exits with code 0
+    And the existing workspace is returned without creating a duplicate
+
+  Scenario: workspace create without --ignore-exists fails when workspace exists
+    Given a workspace "my-app-dev" already exists
+    When I create workspace "my-app-dev" without "--ignore-exists"
+    Then the command exits with code 1
+    And stderr contains "already exists"

--- a/tests/test_api/test_client.py
+++ b/tests/test_api/test_client.py
@@ -356,6 +356,23 @@ class TestRetryLogic:
             f"POST was retried {call_count} times on 409; expected exactly 1 call"
         )
 
+    def test_post_422_raises_conflict_error(self):
+        """POST on 422 Unprocessable Entity raises TFCConflictError.
+
+        TFC returns 422 (not 409) for duplicate workspace names. Both must
+        map to TFCConflictError so --ignore-exists can catch real TFC errors.
+        """
+        creds = TerraformCredentials(host="app.terraform.io", token="test-token")
+        client = TFCClient(credentials=creds)
+
+        def mock_request(method, path, **kwargs):
+            request = httpx.Request(method, f"https://app.terraform.io/api/v2{path}")
+            return httpx.Response(422, request=request)
+
+        with patch.object(client.client, "request", side_effect=mock_request):
+            with pytest.raises(TFCConflictError):
+                client.post("/workspaces", json_data={"data": {}})
+
     def test_post_500_retries(self):
         """POST on 500 Server Error should retry — transient failure is safe assumption."""
         creds = TerraformCredentials(host="app.terraform.io", token="test-token")

--- a/tests/test_cli/test_agent_experience_bdd.py
+++ b/tests/test_cli/test_agent_experience_bdd.py
@@ -1,0 +1,560 @@
+"""BDD step definitions for Agent Experience (AX) CLI features.
+
+Covers AX1 (ID resolver), AX2 (latest run lookups), AX3 (trigger+wait),
+AX4 (state output extraction), AX5 (JSON mutations), AX6 (idempotent create).
+"""
+
+import fnmatch
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+from typer.testing import CliRunner
+
+from terrapyne.cli.main import app
+from terrapyne.models.run import Run
+from terrapyne.models.workspace import Workspace
+from tests.fixtures.factories import run_response, workspace_response
+
+runner = CliRunner()
+
+FEATURE = "../features/agent_experience.feature"
+
+
+# ===========================================================================
+# Scenario declarations
+# ===========================================================================
+
+
+@scenario(FEATURE, "Resolve workspace ID without jq")
+def test_ax1_workspace_id():
+    pass
+
+
+@scenario(FEATURE, "Resolve project ID without jq")
+def test_ax1_project_id():
+    pass
+
+
+@scenario(FEATURE, "Resolving ID for a non-existent workspace exits non-zero")
+def test_ax1_workspace_id_not_found():
+    pass
+
+
+@scenario(FEATURE, "Show logs for the latest run without knowing its ID")
+def test_ax2_run_logs_latest():
+    pass
+
+
+@scenario(FEATURE, "Show run detail for the latest run without knowing its ID")
+def test_ax2_run_show_latest():
+    pass
+
+
+@scenario(FEATURE, "Trigger a run and wait silently for completion")
+def test_ax3_trigger_wait_success():
+    pass
+
+
+@scenario(FEATURE, "Trigger and wait exits non-zero when run errors")
+def test_ax3_trigger_wait_error():
+    pass
+
+
+@scenario(FEATURE, "Extract a single state output value")
+def test_ax4_state_output():
+    pass
+
+
+@scenario(FEATURE, "Extracting a missing state output exits non-zero")
+def test_ax4_state_output_missing():
+    pass
+
+
+@scenario(FEATURE, "workspace create emits JSON with workspace ID")
+def test_ax5_workspace_create_json():
+    pass
+
+
+@scenario(FEATURE, "workspace clone emits JSON with new workspace ID")
+def test_ax5_workspace_clone_json():
+    pass
+
+
+@scenario(FEATURE, "run trigger emits JSON with run ID")
+def test_ax5_run_trigger_json():
+    pass
+
+
+@scenario(FEATURE, "workspace create with --ignore-exists succeeds when workspace already present")
+def test_ax6_ignore_exists_success():
+    pass
+
+
+@scenario(FEATURE, "workspace create without --ignore-exists fails when workspace exists")
+def test_ax6_conflict_fails():
+    pass
+
+
+# ===========================================================================
+# Shared Givens
+# ===========================================================================
+
+
+@given("a terraform cloud organization is accessible")
+def tfc_org_accessible():
+    pass
+
+
+@given(parsers.parse('a workspace "{name}" exists'), target_fixture="workspace_ctx")
+def workspace_ctx(name):
+    return {"name": name, "id": "ws-abc123"}
+
+
+@given(parsers.parse('a project "{name}" exists with id "{proj_id}"'), target_fixture="project_ctx")
+def project_ctx(name, proj_id):
+    return {"name": name, "id": proj_id}
+
+
+@given(
+    parsers.parse('a workspace "{name}" is ready for operations'), target_fixture="workspace_ctx"
+)
+def workspace_ready_ctx(name):
+    return {"name": name, "id": "ws-ready123"}
+
+
+@given(parsers.parse('a workspace "{name}" has runs'), target_fixture="workspace_ctx")
+def workspace_has_runs_ctx(name):
+    return {"name": name, "id": "ws-runs123"}
+
+
+@given(
+    parsers.parse('a workspace "{name}" has a most recent run "{run_id}"'),
+    target_fixture="workspace_ctx",
+)
+def workspace_latest_run_ctx(name, run_id):
+    return {"name": name, "id": "ws-latest123", "latest_run_id": run_id}
+
+
+@given(parsers.parse('a workspace "{name}" already exists'), target_fixture="workspace_ctx")
+def workspace_already_exists_ctx(name):
+    return {"name": name, "id": "ws-exists123"}
+
+
+@given(
+    parsers.parse('a workspace with output "{key}" = "{value}"'),
+    target_fixture="output_ctx",
+)
+def output_ctx(key, value):
+    return {"key": key, "value": value}
+
+
+@given(parsers.parse('a workspace with no output named "{key}"'), target_fixture="output_ctx")
+def no_output_ctx(key):
+    return {"key": key, "value": None}
+
+
+# ===========================================================================
+# AX1 — Whens
+# ===========================================================================
+
+
+@when(parsers.parse('I run "tfc workspace id {name}"'), target_fixture="cli_result")
+def run_workspace_id(name, workspace_ctx):
+    ws = Workspace.from_api_response(workspace_response(id=workspace_ctx["id"], name=name)["data"])
+    with patch("terrapyne.cli.workspace_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = ws
+        return runner.invoke(app, ["workspace", "id", name, "--organization", "test-org"])
+
+
+@when("I resolve the id of a workspace that does not exist", target_fixture="cli_result")
+def run_workspace_id_not_found():
+    from terrapyne.core.exceptions import TFCNotFoundError
+
+    with patch("terrapyne.cli.workspace_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.side_effect = TFCNotFoundError("not found")
+        return runner.invoke(
+            app, ["workspace", "id", "no-such-workspace", "--organization", "test-org"]
+        )
+
+
+@when(parsers.parse('I run "tfc project id {name}"'), target_fixture="cli_result")
+def run_project_id(name, project_ctx):
+    from terrapyne.models.project import Project
+
+    proj = MagicMock(spec=Project)
+    proj.id = project_ctx["id"]
+    proj.name = name
+    with patch("terrapyne.cli.project_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.projects.get_by_name.return_value = proj
+        return runner.invoke(app, ["project", "id", name, "--organization", "test-org"])
+
+
+# ===========================================================================
+# AX2 — Whens
+# ===========================================================================
+
+
+@when(
+    parsers.parse('I run "tfc run logs --workspace {name} --latest"'),
+    target_fixture="cli_result",
+)
+def run_logs_latest(name, workspace_ctx):
+    ws = Workspace.from_api_response(workspace_response(id=workspace_ctx["id"], name=name)["data"])
+    run = Run.from_api_response(run_response(id="run-latest-001")["data"])
+    with patch("terrapyne.cli.run_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = ws
+        mock_client.runs.list.return_value = (iter([run]), 1)
+        mock_client.runs.get.return_value = run
+        mock_client.runs.get_plan_logs.return_value = "Plan log output"
+        mock_client.runs.get_plan.return_value = MagicMock(log_read_url=None)
+        return runner.invoke(
+            app,
+            ["run", "logs", "--workspace", name, "--latest", "--organization", "test-org"],
+        )
+
+
+@when(
+    parsers.parse('I run "tfc run show --workspace {name} --latest"'),
+    target_fixture="cli_result",
+)
+def run_show_latest(name, workspace_ctx):
+    ws = Workspace.from_api_response(workspace_response(id=workspace_ctx["id"], name=name)["data"])
+    latest_run_id = workspace_ctx.get("latest_run_id", "run-latest-001")
+    run = Run.from_api_response(run_response(id=latest_run_id)["data"])
+    with patch("terrapyne.cli.run_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = ws
+        mock_client.runs.list.return_value = (iter([run]), 1)
+        mock_client.runs.get.return_value = run
+        return runner.invoke(
+            app,
+            ["run", "show", "--workspace", name, "--latest", "--organization", "test-org"],
+        )
+
+
+# ===========================================================================
+# AX3 — Whens
+# ===========================================================================
+
+
+@when(
+    parsers.parse('I trigger a run for "{name}" with "--wait"'),
+    target_fixture="cli_result",
+)
+def trigger_wait_success(name, workspace_ctx):
+    ws = Workspace.from_api_response(workspace_response(id=workspace_ctx["id"], name=name)["data"])
+    run = Run.from_api_response(run_response(id="run-wait-001", status="applied")["data"])
+    with patch("terrapyne.cli.run_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = ws
+        mock_client.runs.get_active_runs.return_value = []
+        mock_client.runs.create.return_value = run
+        mock_client.runs.poll_until_complete.return_value = run
+        return runner.invoke(
+            app,
+            ["--quiet", "run", "trigger", name, "--wait", "--organization", "test-org"],
+        )
+
+
+@when(
+    parsers.parse('I trigger a run for "{name}" with "--wait" and the run errors'),
+    target_fixture="cli_result",
+)
+def trigger_wait_error(name, workspace_ctx):
+    ws = Workspace.from_api_response(workspace_response(id=workspace_ctx["id"], name=name)["data"])
+    pending = Run.from_api_response(run_response(id="run-err-001", status="pending")["data"])
+    errored = Run.from_api_response(run_response(id="run-err-001", status="errored")["data"])
+    with patch("terrapyne.cli.run_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = ws
+        mock_client.runs.get_active_runs.return_value = []
+        mock_client.runs.create.return_value = pending
+        mock_client.runs.poll_until_complete.return_value = errored
+        return runner.invoke(
+            app,
+            ["--quiet", "run", "trigger", name, "--wait", "--organization", "test-org"],
+        )
+
+
+# ===========================================================================
+# AX4 — Whens
+# ===========================================================================
+
+
+@when(
+    parsers.parse('I run "tfc state output {workspace} {key}"'),
+    target_fixture="cli_result",
+)
+def run_state_output(workspace, key, output_ctx):
+    ws = Workspace.from_api_response(workspace_response(name=workspace)["data"])
+    sv = MagicMock()
+    sv.id = "sv-abc123"
+
+    if output_ctx["value"] is not None:
+        mock_output = MagicMock()
+        mock_output.name = key
+        mock_output.value = output_ctx["value"]
+        mock_output.sensitive = False
+        outputs = [mock_output]
+    else:
+        outputs = []
+
+    with patch("terrapyne.cli.state_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = ws
+        mock_client.state_versions.get_current.return_value = sv
+        mock_client.state_versions.list_outputs.return_value = outputs
+        return runner.invoke(
+            app,
+            ["state", "output", workspace, key, "--organization", "test-org"],
+        )
+
+
+# ===========================================================================
+# AX5 — Whens
+# ===========================================================================
+
+
+@when(
+    parsers.parse('I create workspace "{name}" with "--format json"'),
+    target_fixture="cli_result",
+)
+def create_workspace_json(name):
+    ws = Workspace.from_api_response(workspace_response(id="ws-newws123", name=name)["data"])
+    with patch("terrapyne.cli.workspace_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.create.return_value = ws
+        return runner.invoke(
+            app,
+            ["workspace", "create", name, "--format", "json", "--organization", "test-org"],
+        )
+
+
+@when(
+    parsers.parse('I clone "{src}" to "{dst}" with "--format json"'),
+    target_fixture="cli_result",
+)
+def clone_workspace_json(src, dst, workspace_ctx):
+    src_ws = Workspace.from_api_response(
+        workspace_response(id=workspace_ctx["id"], name=src)["data"]
+    )
+    dst_ws = Workspace.from_api_response(workspace_response(id="ws-newclone1", name=dst)["data"])
+    with patch("terrapyne.cli.workspace_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = src_ws
+        with patch("terrapyne.api.workspace_clone.CloneWorkspaceAPI") as mock_clone_cls:
+            mock_clone = MagicMock()
+            mock_clone_cls.return_value = mock_clone
+            mock_clone.clone.return_value = {
+                "status": "success",
+                "message": "Cloned successfully",
+                "workspace": dst_ws,
+                "results": {},
+            }
+            return runner.invoke(
+                app,
+                ["workspace", "clone", src, dst, "--format", "json", "--organization", "test-org"],
+            )
+
+
+@when(
+    parsers.parse('I trigger a run for "{name}" with "--format json"'),
+    target_fixture="cli_result",
+)
+def trigger_run_json(name, workspace_ctx):
+    ws = Workspace.from_api_response(workspace_response(id=workspace_ctx["id"], name=name)["data"])
+    run = Run.from_api_response(run_response(id="run-json001", status="pending")["data"])
+    with patch("terrapyne.cli.run_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.get.return_value = ws
+        mock_client.runs.get_active_runs.return_value = []
+        mock_client.runs.create.return_value = run
+        return runner.invoke(
+            app,
+            [
+                "run",
+                "trigger",
+                name,
+                "--no-wait",
+                "--format",
+                "json",
+                "--organization",
+                "test-org",
+            ],
+        )
+
+
+# ===========================================================================
+# AX6 — Whens
+# ===========================================================================
+
+
+@when(
+    parsers.parse('I create workspace "{name}" with "--ignore-exists"'),
+    target_fixture="cli_result",
+)
+def create_workspace_ignore_exists(name, workspace_ctx):
+    from terrapyne.core.exceptions import TFCConflictError
+
+    existing = Workspace.from_api_response(
+        workspace_response(id=workspace_ctx["id"], name=name)["data"]
+    )
+    with patch("terrapyne.cli.workspace_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.create.side_effect = TFCConflictError("already exists")
+        mock_client.workspaces.get.return_value = existing
+        return runner.invoke(
+            app,
+            ["workspace", "create", name, "--ignore-exists", "--organization", "test-org"],
+        )
+
+
+@when(
+    parsers.parse('I create workspace "{name}" without "--ignore-exists"'),
+    target_fixture="cli_result",
+)
+def create_workspace_no_ignore(name, workspace_ctx):
+    from terrapyne.core.exceptions import TFCConflictError
+
+    with patch("terrapyne.cli.workspace_cmd.get_client") as mock_gc:
+        mock_client = MagicMock()
+        mock_gc.return_value.__enter__.return_value = mock_client
+        mock_client.workspaces.create.side_effect = TFCConflictError("already exists")
+        return runner.invoke(
+            app,
+            ["workspace", "create", name, "--organization", "test-org"],
+        )
+
+
+# ===========================================================================
+# Shared Thens
+# ===========================================================================
+
+
+@then(parsers.parse('stdout is exactly "{expected}"'))
+def stdout_exactly(cli_result, expected):
+    actual = cli_result.stdout.strip()
+    assert actual == expected, f"Expected {expected!r}, got {actual!r}"
+
+
+@then("there is no extra formatting")
+def no_extra_formatting(cli_result):
+    output = cli_result.stdout.strip()
+    assert "\n" not in output, f"Unexpected newline in output: {output!r}"
+
+
+@then("the exit code is 1")
+def exit_code_1(cli_result):
+    assert cli_result.exit_code == 1, (
+        f"Expected exit 1, got {cli_result.exit_code}\nOutput: {cli_result.stdout}"
+    )
+
+
+@then(parsers.parse('stderr contains "{text}"'))
+def stderr_contains(cli_result, text):
+    combined = cli_result.stdout + (cli_result.stderr or "")
+    assert text.lower() in combined.lower(), f"Expected {text!r} in output, got: {combined!r}"
+
+
+@then("the logs for the most recent run are shown")
+def logs_shown(cli_result):
+    assert cli_result.exit_code == 0, (
+        f"Expected exit 0, got {cli_result.exit_code}\n{cli_result.stdout}"
+    )
+
+
+@then(parsers.parse('the run detail for "{run_id}" is shown'))
+def run_detail_shown(cli_result, run_id):
+    assert cli_result.exit_code == 0, (
+        f"Expected exit 0, got {cli_result.exit_code}\n{cli_result.stdout}"
+    )
+    assert run_id in cli_result.stdout
+
+
+@then("the command blocks until the run reaches a terminal state")
+def command_blocks(cli_result):
+    assert cli_result.exit_code == 0
+
+
+@then("no plan or apply logs are streamed")
+def no_logs_streamed(cli_result):
+    output = cli_result.stdout
+    assert "Plan:" not in output
+    assert "Apply:" not in output
+
+
+@then("the command exits with code 0 on success")
+def exits_0_on_success(cli_result):
+    assert cli_result.exit_code == 0, f"Expected 0, got {cli_result.exit_code}\n{cli_result.stdout}"
+
+
+@then("the command exits with code 0")
+def exits_0(cli_result):
+    assert cli_result.exit_code == 0, f"Expected 0, got {cli_result.exit_code}\n{cli_result.stdout}"
+
+
+@then("the command exits with code 1")
+def exits_1(cli_result):
+    assert cli_result.exit_code == 1, f"Expected 1, got {cli_result.exit_code}\n{cli_result.stdout}"
+
+
+@then("there is no table formatting")
+def no_table_formatting(cli_result):
+    output = cli_result.stdout
+    assert "─" not in output
+    assert "│" not in output
+
+
+@then("stdout is valid JSON")
+def stdout_is_valid_json(cli_result):
+    try:
+        json.loads(cli_result.stdout)
+    except json.JSONDecodeError as e:
+        pytest.fail(f"stdout is not valid JSON: {e}\nOutput: {cli_result.stdout!r}")
+
+
+@then(parsers.parse('the JSON contains field "{field}" matching "{pattern}"'))
+def json_field_matches_pattern(cli_result, field, pattern):
+    data = json.loads(cli_result.stdout)
+    assert field in data, f"Field {field!r} not in JSON: {data}"
+    assert fnmatch.fnmatch(str(data[field]), pattern), (
+        f"Field {field!r}={data[field]!r} does not match {pattern!r}"
+    )
+
+
+@then(parsers.parse('the JSON contains field "{field}" = "{expected}"'))
+def json_field_equals(cli_result, field, expected):
+    data = json.loads(cli_result.stdout)
+    assert field in data, f"Field {field!r} not in JSON: {data}"
+    assert str(data[field]) == expected, (
+        f"Field {field!r}: expected {expected!r}, got {data[field]!r}"
+    )
+
+
+@then(parsers.parse('the JSON contains field "{field}"'))
+def json_has_field(cli_result, field):
+    data = json.loads(cli_result.stdout)
+    assert field in data, f"Field {field!r} not in JSON: {data}"
+
+
+@then("the existing workspace is returned without creating a duplicate")
+def existing_workspace_returned(cli_result):
+    assert cli_result.exit_code == 0, f"Expected 0, got {cli_result.exit_code}\n{cli_result.stdout}"


### PR DESCRIPTION
## Summary

AI coding agents orchestrating TFC workflows have been forced to write bash glue (jq pipes, polling loops, output parsing) because terrapyne lacked first-class primitives for common patterns. This PR eliminates that glue for six identified friction points.

| Item | Feature | Command |
|------|---------|---------|
| AX1 | Universal ID resolver | `tfc workspace id <ws>` / `tfc project id <p>` |
| AX2 | Latest run lookups | `run logs --latest` / `run show --latest` |
| AX3 | Trigger & wait (silent) | `run trigger --wait` (default changed to `--no-wait`) |
| AX4 | State output extraction | `tfc state output <ws> <key>` |
| AX5 | JSON output on mutations | `--format json` on `workspace create`, `workspace clone`, `run trigger` |
| AX6 | Idempotent create | `workspace create --ignore-exists` |

## Test plan

- [ ] 14 new BDD scenarios in `tests/features/agent_experience.feature`
- [ ] 802 tests passing, 0 failures
- [ ] mypy clean, ruff clean
- [ ] Pre-commit hooks pass on push