### PR TITLE
chore: agent guardrails, audit targets, and conftest hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,29 @@ uv run mypy src/                # Type check
 This file uses progressive disclosure. For detailed instructions on how agents should operate within this codebase, please refer to the following critical guides:
 
 - **[Agent Workflow Guide](file:///home/unop/shalomb/terrapyne/docs/how-to/agent-workflow.md)** — **CRITICAL**: The strict BDD/TDD Red-Green-Refactor cycle, ACP commit protocol, and mandatory Adversarial Review (Bart) rules.
+- **[Epic Handoff](file:///home/unop/shalomb/terrapyne/docs/how-to/epic-handoff.md)** — How epics move from Marge → Lisa → Ralph → Bart; the `TODO-{td-id}.md` format.
 - **[Python & Testing](file:///home/unop/shalomb/terrapyne/docs/how-to/python-and-testing.md)** — Type hints, imports, test structure, pytest-bdd patterns.
 - **[BDD Specifications](file:///home/unop/shalomb/terrapyne/docs/explanation/bdd-specifications.md)** — Writing Adzic-aligned feature files and step definitions.
 - **[Commits & Review](file:///home/unop/shalomb/terrapyne/docs/how-to/commits-and-review.md)** — Atomic commits, conventional format, PR process.
 - **[Architecture](file:///home/unop/shalomb/terrapyne/docs/explanation/architecture/)** — ADRs, design decisions, model patterns.
+
+## Standards (cited from the agent personas)
+
+These are the canonical rule sets that the Marge / Lisa / Ralph / Bart personas reference. Read them before doing your role.
+
+- **[Atomic Commit Protocol](file:///home/unop/shalomb/terrapyne/docs/standards/atomic-commit-protocol.md)** — One reason to change, verified before commit, Conventional Commits format.
+- **[Task Decomposition](file:///home/unop/shalomb/terrapyne/docs/standards/task-decomposition.md)** — INVEST plus the five decomposition strategies (Ralph applies these).
+- **[Adversarial Review Feedback](file:///home/unop/shalomb/terrapyne/docs/standards/feedback.md)** — `FEEDBACK.md` template; What/Why/How/Priority pattern (Bart applies this).
+
+## Quality indices (the rubrics)
+
+- **[Farley Index](file:///home/unop/shalomb/terrapyne/docs/reference/farley-index.md)** — Test-suite scoring rubric. Target ≥ 7.0 per property.
+- **[Adzic Index](file:///home/unop/shalomb/terrapyne/docs/reference/adzic-index.md)** — BDD-quality scoring rubric. Target ≥ 7.0 per dimension.
+
+## Planning artifacts
+
+- **[PLAN.md](file:///home/unop/shalomb/terrapyne/PLAN.md)** — Marge's epic register. Read before starting any work to confirm your epic exists and is approved.
+- **[TODO.md](file:///home/unop/shalomb/terrapyne/TODO.md)** — Operational backlog with WSJF-ranked tasks; bugs and small fixes that don't warrant an epic.
 
 ## Essential Skills
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,51 @@ test-typecheck: ## Rung 0.35: Type check (blocking)
 test-lint: ## Rung 0.5: Full lint (blocking)
 	uv run ruff check src/ tests/
 
+audit-patches: ## Rung 0.4: Fail on patches against deprecated stub modules (blocking)
+	@# tests must not patch terrapyne.cli.utils.* — that module is a deprecated
+	@# stub. The real symbols live in cli/context_helpers.py and the per-command
+	@# files; patching the stub silently no-ops. See PLAN.md EPIC-001.
+	@if grep -RnE 'patch\(\s*"terrapyne\.cli\.utils\.[A-Za-z_]+"' tests/ src/; then \
+		echo ""; \
+		echo "❌ Found patch() calls against terrapyne.cli.utils.*"; \
+		echo "   That module is a deprecated stub. Patch the real import site instead."; \
+		echo "   See docs/how-to/python-and-testing.md and PLAN.md EPIC-001."; \
+		exit 1; \
+	fi
+	@# Tests should use error_console for stderr expectations rather than asserting
+	@# on private console attributes; flag drift early. (Informational, non-blocking.)
+	@echo "✅ audit-patches: no patches against deprecated stubs"
+
+audit-ai-markers: ## Rung 0.4: Fail if AI-attribution markers leak into commits or tree (blocking)
+	@# The PR template, agent personas, and commits-and-review.md all forbid AI
+	@# markers in commits and code. This audits src/, tests/, and the recent
+	@# commit log on this branch for the most common offenders.
+	@#
+	@# docs/ is intentionally excluded: the standards documents describe these
+	@# patterns by name (so contributors know what's forbidden) which would
+	@# otherwise self-trip the audit.
+	@FAIL=0; \
+	if grep -RInE 'Co-Authored-By:[[:space:]]*(Claude|GPT|Gemini|Copilot|Cursor)' src/ tests/ 2>/dev/null; then \
+		echo "❌ AI co-author markers found in working tree"; \
+		FAIL=1; \
+	fi; \
+	if grep -RInE '🤖[[:space:]]*Generated with' src/ tests/ 2>/dev/null; then \
+		echo "❌ '🤖 Generated with' marker found in working tree"; \
+		FAIL=1; \
+	fi; \
+	if [ -d .git ] && git log -n 50 --format='%B' 2>/dev/null | \
+		grep -InE 'Co-Authored-By:[[:space:]]*(Claude|GPT|Gemini|Copilot|Cursor)|🤖[[:space:]]*Generated with' >/dev/null; then \
+		echo "❌ AI marker found in recent commit messages on this branch"; \
+		FAIL=1; \
+	fi; \
+	if [ "$$FAIL" = "1" ]; then \
+		echo ""; \
+		echo "   See docs/how-to/commits-and-review.md and the GenAI section of"; \
+		echo "   .github/PULL_REQUEST_TEMPLATE.md."; \
+		exit 1; \
+	fi
+	@echo "✅ audit-ai-markers: no AI attribution markers found"
+
 test-last-failed: ## Rung 1.0: Regressions (fast)
 	uv run python -m pytest tests/ --lf -x -q --no-header --no-cov || true
 
@@ -102,7 +147,7 @@ test-all: ## Rung 2.0: Logic / Full suite (blocking)
 test-coverage: ## Rung 3.0: Coverage report (informational)
 	uv run python -m pytest tests/ --cov=src --cov-report=term --no-header -q --no-cov-on-fail || true
 
-test-fast: test-structure test-imports test-typecheck test-lint ## Inner Loop: Rungs 0.0 - 0.5 (< 10s)
+test-fast: test-structure test-imports test-typecheck test-lint audit-patches audit-ai-markers ## Inner Loop: Rungs 0.0 - 0.5 (< 10s)
 
 test-ci: test-fast test-last-failed test-all test-coverage ## Outer Loop: Full ladder accordion
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,595 @@
+# PLAN.md — Terrapyne Product Plan
+
+> **Intent Layer.** This file is owned by Marge (Product Agent). Each epic captures the *Why* and *What*. Implementation tasks live in `TODO.md` (the operational backlog) and individual `.feature` files under `tests/features/` (the executable BDD specifications).
+
+## How this file works
+
+- **PLAN.md** = epics + feature briefs (durable, stakeholder-readable, *why this matters*).
+- **TODO.md** = WSJF-ranked, sized, status-tracked task backlog (*what to do next*).
+- **tests/features/*.feature** = executable acceptance criteria (*proof we built the right thing*).
+- **`td`** = ephemeral epic/task IDs once initialised (`td init && td epic create ...`).
+
+Each epic has an ID `EPIC-XXX` that maps 1:1 to a `td` epic ID once registered. Feature scenarios in `.feature` files cite their `EPIC-XXX` in tags so traceability is preserved without tooling.
+
+---
+
+## Epic index
+
+| ID         | Title                                                | Track            | Priority | Status |
+| ---------- | ---------------------------------------------------- | ---------------- | -------- | ------ |
+| EPIC-001   | Restore Test-Suite Repeatability                     | Quality / TDD    | P0       | Draft  |
+| EPIC-002   | Honour the Documented Automation Contract            | Agent Experience | P0       | Draft  |
+| EPIC-003   | Structured Output for Mutating Commands              | Agent Experience | P0       | Draft  |
+| EPIC-004   | Frictionless Scripting & Non-Interactive Use         | Scripting        | P1       | Draft  |
+| EPIC-005   | Pagination Honesty in the SDK                        | SDK Correctness  | P1       | Draft  |
+| EPIC-006   | Decompose CLI Command Modules                        | Maintainability  | P2       | Draft  |
+| EPIC-007   | Push Orchestration from CLI into the SDK             | Architecture     | P2       | Draft  |
+| EPIC-008   | OpenTofu Support in `terrapyne.local`                | Platform Reach   | P1       | Draft  |
+| EPIC-009   | Async TFCClient                                      | Platform Reach   | P3       | Parked |
+| EPIC-010   | Plugin Model for Custom Command Groups               | Platform Reach   | P3       | Parked |
+
+Priority legend: **P0** = blocks trust in the product; **P1** = visible user pain; **P2** = compounds into pain over time; **P3** = future-looking.
+
+---
+
+## EPIC-001 — Restore Test-Suite Repeatability
+
+**td:** *(unregistered)*  •  **Track:** Quality / TDD  •  **Priority:** P0
+
+### Problem Statement
+
+The test suite reports 815 passing under `make test-all`, but running subsets (e.g. `pytest tests/test_cli/`) produces 32+ failures, and at least one test ordering causes pytest to hang. The cause is module-level mutable state on the shared Rich `console` singleton (`console.quiet`, `console._force_terminal`, `console.no_color`) that tests mutate but never reset. A separate, latent issue: a BDD step in `test_run_commands.py` patches `terrapyne.cli.utils.validate_context`, but `cli/utils.py` is a deprecated stub — the patch silently no-ops, the real `validate_context` is called, and credential resolution is attempted against the live filesystem.
+
+### User Value
+
+The CI build is a lie if the suite isn't repeatable. Contributors waste hours chasing phantom failures that depend on test order. New BDD authors hit failures that have nothing to do with their changes. Once Repeatable is restored, every other quality signal (coverage, Farley index, Adzic index) becomes trustworthy.
+
+### Success Metrics
+
+- `pytest tests/` passes in any subset and any order (verified with shuffled execution and individual file runs).
+- `pytest -p pytest_randomly` is added to the inner-loop test ladder; suite remains green across N=10 random orderings.
+- `make test-fast` time stays under 10 seconds.
+- Zero broken `patch()` targets in the test tree (verified by a small grep-based lint).
+
+### Unknowns
+
+- Whether other shared singletons (logger handlers, `os.environ` mutations from `setup_logging`) leak across tests in addition to the console.
+- Whether re-using `pytest-xdist` (already in dev deps) would surface additional ordering bugs.
+
+### Risks
+
+- Adding an `autouse` reset fixture could mask intentional console state in tests that *want* to assert on it. Mitigation: the fixture restores prior values rather than forcing defaults.
+
+### Out of Scope
+
+- Refactoring the Rich console singletons themselves (deferred to EPIC-006/EPIC-007).
+- Adding pytest-randomly to dev deps in this epic; do that as a follow-up after the autouse fixture is in.
+
+### Acceptance Criteria — `tests/features/test_repeatability.feature` *(to author)*
+
+```gherkin
+Feature: Test suite is repeatable across orderings
+  As a contributor
+  I want the test suite to pass regardless of execution order
+  So I can trust CI signals and onboard new tests safely
+
+  Scenario: Running individual test files in isolation passes
+    Given any single test file under tests/
+    When that file is invoked alone via pytest
+    Then it passes with the same outcome as in the full-suite run
+
+  Scenario: Running the suite under randomised ordering passes
+    Given the full test suite
+    When pytest is invoked with a randomised order seed
+    Then the suite passes for ten consecutive runs
+
+  Scenario: A test that mutates the shared console does not leak
+    Given a test that sets console.quiet to True
+    When the test completes
+    Then the next test observes console.quiet at its prior value
+```
+
+---
+
+## EPIC-002 — Honour the Documented Automation Contract
+
+**td:** *(unregistered)*  •  **Track:** Agent Experience  •  **Priority:** P0
+
+### Problem Statement
+
+`docs/explanation/design-philosophy.md` makes five explicit promises about CLI behaviour:
+
+1. Output guides the next action.
+2. **stdout for data, stderr for everything else.**
+3. Structured output is a contract, not a convenience.
+4. Errors are actionable.
+5. No interactive requirements (every prompt has a non-interactive bypass).
+
+Items 2 and 3 are partially broken today. The single greatest violation: `tfc workspace list -o nonexistent --format json 2>/dev/null` writes the human-readable error to **stdout**, polluting the JSON stream. `error_console = Console(file=stderr)` exists in `rendering/logging.py` but is used by only one CLI module (`state_cmd.py`); 220 `console.print()` call sites across 12 CLI files write all UX (errors, warnings, progress) to stdout.
+
+### User Value
+
+When the contract holds, `tfc anything --format json | jq` Just Works — and that's the foundation every CI script, agent toolchain, and pipe-based automation depends on. When it doesn't, every consumer has to wrap calls in error-stripping logic, defeating the purpose of having `--format json` at all.
+
+### Success Metrics
+
+- `tfc <any-read-command> --format json 2>/dev/null` produces valid JSON in every error scenario.
+- `tfc <any-read-command> --format json >/dev/null` shows all human messages on stderr.
+- Adding a regression test that pipes JSON output to `jq` for every read command and expects exit code 0.
+- A linting rule (or audit script) flags `console.print(` for messages that contain `[red]Error` or `[yellow]Warning`.
+
+### Unknowns
+
+- Whether to introduce a thin `ux.warn()` / `ux.error()` / `ux.progress()` helper layer or migrate every call site directly. Lisa to decide.
+- Whether to also redirect *progress spinners* (currently absent) to stderr by convention.
+
+### Risks
+
+- A wide refactor risks regression. Mitigation: drive it from a generated audit list, file by file, with the test suite as guardrail (after EPIC-001 is fixed).
+
+### Out of Scope
+
+- Introducing the `ux` helper module — that's a Lisa-track design decision.
+- Adding `--format json` to mutations (covered by EPIC-003).
+
+### Acceptance Criteria — `tests/features/stdout_stderr_separation.feature` *(to author)*
+
+```gherkin
+Feature: stdout carries data, stderr carries human text
+  As an automation author
+  I want clean separation between machine output and human output
+  So that piping JSON to jq always works, even on errors
+
+  Scenario: A successful read command writes JSON to stdout only
+    Given a command that supports --format json
+    When the command runs successfully
+    Then stdout contains valid JSON
+    And stderr is empty or contains only progress messages
+
+  Scenario: A failing read command emits error text to stderr
+    Given an organization name that does not exist
+    When I run "tfc workspace list -o ghost --format json"
+    Then stdout is either empty or contains valid JSON
+    And stderr contains the human-readable error
+    And the exit code is non-zero
+
+  Scenario: Progress messages do not contaminate JSON output
+    Given a command that prints progress hints in TTY mode
+    When stdout is redirected to a file and --format json is used
+    Then the file contains exactly one valid JSON document
+```
+
+---
+
+## EPIC-003 — Structured Output for Mutating Commands
+
+**td:** *(unregistered)*  •  **Track:** Agent Experience  •  **Priority:** P0
+
+### Problem Statement
+
+The design philosophy commits to `--format json` on every command, "including mutations". Today, `emit_json` is called from 19 sites — all on read paths. `workspace create`, `workspace clone`, `workspace update`, `workspace delete`, `run trigger`, `run apply`, `run discard`, `run cancel`, `var set`, `var remove`, `var copy`, `varset apply`, `team create`, `team add-member`, and others have no JSON output at all. The result: agents and CI scripts cannot chain mutations:
+
+```bash
+WS_ID=$(tfc workspace create app-staging --format json | jq -r '.id')   # Today: parses ANSI human text
+tfc run trigger -w app-staging --format json | jq -r '.run_id'           # Today: empty
+```
+
+### User Value
+
+Pipelines, GitOps bots, and AI agents stop needing fragile screen-scraping. The "Output guides the next action" principle becomes real: a mutation tells the caller exactly what was created and what to do next.
+
+### Success Metrics
+
+- Every mutating command supports `--format json`.
+- The JSON envelope is consistent across mutations:
+  ```json
+  {
+    "id": "ws-abc123",
+    "type": "workspace",
+    "name": "app-staging",
+    "url": "https://app.terraform.io/app/my-org/workspaces/app-staging",
+    "next_actions": ["tfc run trigger -w app-staging"]
+  }
+  ```
+- BDD coverage: one scenario per mutation verifies the JSON envelope shape.
+
+### Unknowns
+
+- Final shape of the JSON envelope (single `{"data": {...}}` wrapper, or flat?). Marge proposes flat with `id` + `type` always present; Lisa to validate.
+- Whether `next_actions` is an array of strings (commands) or structured objects (`{"command": "...", "description": "..."}`). Strings are simplest; objects degrade gracefully if requirements grow.
+
+### Risks
+
+- Inconsistent envelopes across mutations would defeat the purpose. Mitigation: introduce a tiny `emit_mutation_result()` helper that all commands use.
+- Backwards compatibility: human-output should still work for terminal users. Verify with `--format table` (default) tests on every mutation.
+
+### Out of Scope
+
+- Idempotence flags (`--ignore-exists`, `--auto-approve`) — covered by EPIC-004.
+- Universal ID resolver (`tfc workspace use NAME` semantics) — TODO.md AX1, deferred.
+
+### Acceptance Criteria — `tests/features/mutation_json_output.feature` *(to author)*
+
+```gherkin
+Feature: Mutations emit machine-readable output
+  As an agent or pipeline
+  I want JSON output from create/update/delete/trigger commands
+  So I can chain operations without parsing human text
+
+  Scenario Outline: A successful mutation emits a JSON envelope
+    Given the appropriate target resource exists or does not exist
+    When I run "<command> --format json"
+    Then stdout contains a JSON object with keys "id", "type", "url"
+    And the JSON contains a "next_actions" array with at least one suggestion
+
+    Examples:
+      | command                                     |
+      | tfc workspace create app-staging            |
+      | tfc workspace clone src --new-name dst      |
+      | tfc workspace update app-staging --tf-version 1.9.0 |
+      | tfc run trigger -w app-staging              |
+      | tfc workspace var set -w app-staging --key region --value eu-west-1 |
+
+  Scenario: A failing mutation still emits structured error JSON
+    Given a workspace name that already exists
+    When I run "tfc workspace create app-staging --format json"
+    Then stderr contains the error message
+    And stdout contains a JSON object with key "error"
+    And the exit code is non-zero
+```
+
+---
+
+## EPIC-004 — Frictionless Scripting & Non-Interactive Use
+
+**td:** *(unregistered)*  •  **Track:** Scripting  •  **Priority:** P1
+
+### Problem Statement
+
+A handful of small bugs make `tfc` unfit for unattended scripts:
+
+- **B13**: `run trigger` exits non-zero on success, breaking `&&` chains.
+- **B14**: `workspace var-rm` always prompts; no `--yes`/`-y`. Unusable in CI.
+- **B15**: `--quiet` is position-sensitive — `tfc workspace list --quiet` fails; only `tfc --quiet workspace list` works. Every shell user types it the wrong way at least once.
+- **B12**: `workspace list` truncates names; no `--no-truncate` or `--max-width`. Output isn't deterministic for downstream tools.
+- **B9**: `run list -w <name>` fails for some workspaces — must use workspace ID.
+
+Each bug individually is small; collectively they signal "not built for scripts."
+
+### User Value
+
+Engineers stop reaching for the TFC web UI for "just one quick thing in a script." Confidence in CI grows. Onboarding new engineers becomes faster (no tribal knowledge about flag positions).
+
+### Success Metrics
+
+- Every flag works in any position (root or sub-app).
+- Every interactive prompt has a non-interactive bypass (`--yes` / `--auto-approve`).
+- `run trigger` exits 0 on success.
+- `tfc workspace list --no-truncate --format table` produces stable, deterministic output.
+- `tfc run list -w <name>` works for any workspace name.
+
+### Unknowns
+
+- Root cause of B9 (workspace name lookup): may be a TFC API quirk vs name normalisation in `WorkspaceAPI.get`. Investigation task before implementation.
+- Whether `--quiet` should propagate via Typer `context_settings` or via env var (`TERRAPYNE_QUIET=1`).
+
+### Risks
+
+- Changing exit codes is a backwards-incompatible behavioural change. Mitigation: 0.x version freedom, document in CHANGELOG.
+
+### Out of Scope
+
+- The deeper `tfc local` / `tfc cloud` split (covered by EPIC-008).
+
+### Acceptance Criteria — `tests/features/scripting_polish.feature` *(to author; portions exist)*
+
+```gherkin
+Feature: Terrapyne is friendly to non-interactive scripts
+  As a CI pipeline
+  I want flags that work in any position and prompts I can bypass
+  So that scripts behave predictably
+
+  Scenario: --quiet works as a sub-app flag
+    When I run "tfc workspace list -o my-org --quiet"
+    Then the command succeeds
+    And no progress text is printed
+
+  Scenario: var-rm has a --yes bypass
+    Given a workspace with variable "region"
+    When I run "tfc workspace var remove --key region -w app --yes"
+    Then no prompt is shown
+    And the variable is removed
+
+  Scenario: run trigger exits 0 on a successful trigger
+    Given a workspace ready for runs
+    When I run "tfc run trigger -w app && echo CHAINED"
+    Then "CHAINED" appears in the output
+
+  Scenario: workspace list output is deterministic with --no-truncate
+    Given workspaces with long names
+    When I run "tfc workspace list --no-truncate"
+    Then no name in the output is suffixed with an ellipsis
+```
+
+---
+
+## EPIC-005 — Pagination Honesty in the SDK
+
+**td:** *(unregistered)*  •  **Track:** SDK Correctness  •  **Priority:** P1
+
+### Problem Statement
+
+`RunsAPI.list(workspace_id, limit=20)` accepts a `limit` parameter that is silently capped at 100 because it issues a single page request (`page[size]=min(limit, 100)`). A user passing `limit=500` gets back the most recent 100 runs and has no signal that data was truncated. Other API methods (e.g. `WorkspaceAPI.list`) correctly use `client.paginate`; this asymmetry is a footgun. The SDK's promise of "high-level abstractions" is broken when one API truncates and others paginate.
+
+### User Value
+
+SDK consumers can write `for run in client.runs.list(ws_id, limit=500): ...` and get 500 runs (or fewer if fewer exist), not 100 with no warning. Trust in the SDK is foundational for the agent-automation use case.
+
+### Success Metrics
+
+- `RunsAPI.list` paginates beyond 100 by default, capped only at the requested `limit`.
+- A clear contract: if `limit` is `None`, fetch all; if numeric, fetch up to that many.
+- Audit of every `*API.list` method in `src/terrapyne/api/`: each either paginates or uses `page_size` instead of `limit` in its signature.
+
+### Unknowns
+
+- Whether to add a streaming iterator API (`client.runs.iter_all(ws_id)`) for long histories. Possibly in a follow-up epic; out of scope here.
+
+### Risks
+
+- Slowing down the default `tfc run list` if pagination is too aggressive. Mitigation: keep CLI default at 20, but make the SDK honest about what it's returning.
+
+### Out of Scope
+
+- Async iteration (deferred to EPIC-009).
+
+### Acceptance Criteria — `tests/features/sdk_pagination.feature` *(to author)*
+
+```gherkin
+Feature: SDK pagination is honest
+  As an SDK consumer
+  I want list APIs to either paginate or to advertise their page-size
+  So I never silently lose data
+
+  Scenario: runs.list with limit > 100 returns up to limit items
+    Given a workspace with 250 runs
+    When I call client.runs.list(workspace_id, limit=200)
+    Then the result contains 200 runs
+    And the total count metadata reports 250
+
+  Scenario: list APIs uniformly accept page_size or paginate
+    Given any *API.list method
+    When the method signature is inspected
+    Then it either paginates internally or exposes page_size, not limit
+```
+
+---
+
+## EPIC-006 — Decompose CLI Command Modules
+
+**td:** *(unregistered)*  •  **Track:** Maintainability  •  **Priority:** P2
+
+### Problem Statement
+
+`cli/run_cmd.py` is 987 lines with 14 commands and 59 `console.print` calls. `cli/workspace_cmd.py` is 957 lines with 17 commands and a nested `var` subgroup. `api/workspace_clone.py` is 739 lines for a single API operation. The pattern of "one big `*_cmd.py` per noun" doesn't scale: every PR touching a command hits a hub file; tests for individual commands have to import a 957-line module; pre-commit hook output for hub-safety fires on most CLI changes. The code is well-written; there's just too much of it in one place.
+
+### User Value
+
+Faster, safer feature work for contributors. Each command becomes 1:1 with a test file, and PRs touch focused files. New command additions don't require navigating thousand-line modules. Hub-safety warnings stop being false-positive noise.
+
+### Success Metrics
+
+- No `cli/*_cmd.py` exceeds 300 lines.
+- Each command has a 1:1 file under `cli/<group>/<command>.py`.
+- `cli/run/__init__.py` (and equivalents) re-exports the Typer `app` for backwards compatibility.
+- Import-linter contracts remain green.
+
+### Unknowns
+
+- Whether to also split `api/workspace_clone.py` (separate API operation). Probably yes; do as a final pass within this epic.
+
+### Risks
+
+- Refactor regression. Mitigation: drive entirely behind the existing test suite (after EPIC-001), with no behavioural changes in this epic.
+
+### Out of Scope
+
+- Pushing orchestration down to the SDK (EPIC-007).
+- Any user-visible behaviour changes.
+
+### Acceptance Criteria
+
+This epic is internal refactoring with no behavioural change. Acceptance is:
+
+- All existing tests pass after refactor (Repeatability gate from EPIC-001 must hold).
+- No file in `src/terrapyne/cli/` exceeds 300 lines.
+- `make test-fast` time does not regress by more than 10 %.
+
+---
+
+## EPIC-007 — Push Orchestration from CLI into the SDK
+
+**td:** *(unregistered)*  •  **Track:** Architecture  •  **Priority:** P2
+
+### Problem Statement
+
+`run trigger` (184 lines in `cli/run_cmd.py`) interleaves orchestration logic — discarding active runs, queue-waiting, polling — with CLI concerns (argument parsing, console output). This logic isn't reusable from the SDK: an automation script importing `terrapyne` cannot do `client.runs.trigger_with_queue_management(...)`; it has to either duplicate the logic or shell out to the CLI. Same pattern applies to log streaming in `run follow` and error-summary computation.
+
+### User Value
+
+SDK consumers (CI tooling, agents, internal portals) can build on the same primitives the CLI uses. The CLI shrinks to a thin presentation layer over a richer SDK.
+
+### Success Metrics
+
+- `RunsAPI` exposes high-level workflows: `trigger_with_queue_management`, `stream_logs`, `get_error_summary` (latter exists already; verify completeness).
+- CLI command bodies are < 50 lines each, mostly mapping arguments to SDK calls and rendering results.
+- SDK reference docs (`docs/reference/sdk.md`) document the new methods.
+
+### Unknowns
+
+- Naming. Marge prefers verbs that read like sentences: `client.runs.trigger(workspace_id, queue_strategy="wait")` over `client.runs.trigger_with_queue_management(...)`. Lisa to decide on signature shape.
+
+### Risks
+
+- Over-abstraction. Mitigation: only push down logic that's already battle-tested in the CLI and clearly user-facing.
+
+### Out of Scope
+
+- New high-level workflows that don't exist in the CLI today (e.g. cross-workspace orchestration).
+
+### Acceptance Criteria — `tests/features/sdk_workflows.feature` *(to author)*
+
+```gherkin
+Feature: SDK exposes high-level run workflows
+  As an SDK consumer
+  I want to trigger a run with queue-management without re-implementing it
+  So I can build automation without duplicating logic
+
+  Scenario: SDK can trigger a run and discard active runs first
+    Given a workspace with one active run
+    When I call client.runs.trigger(workspace_id, queue_strategy="discard_active")
+    Then the active run is discarded
+    And a new run is created
+
+  Scenario: SDK can stream logs without ANSI codes
+    Given a run in progress
+    When I call client.runs.stream_logs(run_id) and read 5 lines
+    Then no ANSI escape sequences appear in any line
+```
+
+---
+
+## EPIC-008 — OpenTofu Support in `terrapyne.local`
+
+**td:** *(unregistered)*  •  **Track:** Platform Reach  •  **Priority:** P1
+
+### Problem Statement
+
+The OpenTofu fork has measurable enterprise adoption. `terrapyne.local.Terraform` currently hard-binds to the `terraform` binary discovered on `$PATH`. Users on OpenTofu projects either can't use Terrapyne for local execution or risk the dangerous footgun of running `terraform` against a `tofu`-managed lockfile (or vice versa). The design has been thought through: see the worktree `feature/opentofu-support` and `docs/features/opentofu-support.md`. The high-level approach: heuristic auto-detection from `.terraform.lock.hcl` and version-manager files, with explicit failure when the matching binary is missing.
+
+A second, related constraint: HashiCorp restricts OpenTofu from natively using Terraform Cloud as a backend. Therefore `terrapyne.api` and `tfc` CLI must explicitly block TFC API operations on detected-OpenTofu projects, with a clear error message rather than a silent failure.
+
+### User Value
+
+OpenTofu users get a Pythonic local-execution wrapper that's safe. Mixed-fleet organisations don't need separate tooling. Migration teams (Terraform → OpenTofu) get a `--force-runner` bypass for the transition window.
+
+### Success Metrics
+
+- `from terrapyne.local import OpenTofu` works.
+- Auto-detection from `.terraform.lock.hcl` (registry URL) and `.opentofu-version` / `.terraform-version` files succeeds for common project shapes.
+- Detection of OpenTofu in a project blocks `tfc` API commands with an actionable error.
+- The migration workflow works via explicit `force_runner=True` (SDK) or `--force-runner tofu` (CLI).
+- A safety test: when OpenTofu is detected but `tofu` is not on `$PATH`, terrapyne fails fast — never silently falls back to `terraform`.
+
+### Unknowns
+
+- Final API shape: `detect_runner(directory) -> Terraform | OpenTofu` factory, or a unified `LocalIACRunner.from_directory(...)` constructor? Lisa decision.
+- Whether to introduce a `tfc local` command group at the same time, or keep that as a follow-up.
+
+### Risks
+
+- Misdetection corrupting state. Mitigation: heuristics are conservative — if signals conflict, fail rather than guess.
+- Drift between Terraform and OpenTofu behaviour. Mitigation: subclass with overrides only where needed; share the bulk of logic via `LocalIACRunner` base.
+
+### Out of Scope
+
+- Full `tfc local plan`, `tfc local validate` agnostic command group (separate epic).
+- Migrating `tests/test_terrapyne_base.py` away from the deprecated `terrapyne.Terraform` import (do as part of this epic's cleanup, but track separately if it grows).
+
+### Acceptance Criteria — `tests/features/opentofu_support.feature` *(to author; design doc exists)*
+
+```gherkin
+Feature: Terrapyne safely runs both Terraform and OpenTofu locally
+  As a developer working in a mixed-fleet organisation
+  I want Terrapyne to detect the correct runner from project files
+  So I never accidentally corrupt state with the wrong binary
+
+  Scenario: An initialized Terraform project picks the terraform binary
+    Given a directory with a .terraform.lock.hcl from "terraform init"
+    When I instantiate the runner via auto-detection
+    Then a Terraform instance is returned
+
+  Scenario: An initialized OpenTofu project picks the tofu binary
+    Given a directory with a .terraform.lock.hcl from "tofu init"
+    When I instantiate the runner via auto-detection
+    Then an OpenTofu instance is returned
+
+  Scenario: Missing matching binary fails fast
+    Given a directory that auto-detects as OpenTofu
+    And the tofu binary is not on $PATH
+    When I instantiate the runner via auto-detection
+    Then a clear error is raised
+    And the error message names "tofu" explicitly
+    And no fallback to "terraform" is attempted
+
+  Scenario: TFC API operations are blocked on OpenTofu projects
+    Given a directory that auto-detects as OpenTofu
+    When I run "tfc workspace list" inside that directory
+    Then the command fails with an actionable error
+    And the error explains that TFC API operations are unsupported on OpenTofu
+
+  Scenario: Migration override is honoured
+    Given a directory that auto-detects as Terraform
+    When I instantiate the runner with force_runner="tofu"
+    Then an OpenTofu instance is returned
+    And a one-time warning is emitted on stderr
+```
+
+---
+
+## EPIC-009 — Async TFCClient *(parked)*
+
+**td:** *(unregistered)*  •  **Track:** Platform Reach  •  **Priority:** P3 (parked)
+
+### Problem Statement
+
+`httpx.AsyncClient` is a sibling of the sync client already in use. An async API surface (`AsyncTFCClient` mirroring `TFCClient`) would unlock concurrent run-status polling across many workspaces, async log streaming, and integration with async-native agent frameworks. Cost is moderate (parallel API class hierarchy) but well-understood given the existing sync structure.
+
+### User Value
+
+Future-looking. Concrete demand will come once Terrapyne is embedded in larger orchestration systems (internal portals, AI agents managing 10+ workspaces concurrently).
+
+### Status
+
+**Parked** until a concrete user pulls. Tracked here so it isn't forgotten.
+
+---
+
+## EPIC-010 — Plugin Model for Custom Command Groups *(parked)*
+
+**td:** *(unregistered)*  •  **Track:** Platform Reach  •  **Priority:** P3 (parked)
+
+### Problem Statement
+
+Once enterprises adopt Terrapyne, they will want to add internal commands (`tfc internal-policy-check`, `tfc cost-allocate`) without forking. A Typer-friendly entry-point–based plugin model (similar to `pip` or `pytest` plugins) would solve this. Not urgent.
+
+### Status
+
+**Parked** until at least one external organisation requests it.
+
+---
+
+## Sequencing Recommendation
+
+Marge's view, applied through the GECR loop:
+
+1. **EPIC-001 first.** Nothing else can be measured trustworthy until the suite is repeatable.
+2. **EPIC-002 and EPIC-003 in parallel** (different files, both governed by the same automation contract). Together they constitute "PR Batch 6" from `TODO.md`.
+3. **EPIC-004** as scripting-polish cleanup once 002/003 have stabilised the contract surface.
+4. **EPIC-005** alongside 004 — same SDK area, same kind of correctness work.
+5. **EPIC-006** before **EPIC-007** — split first, then push down. Easier reviews, fewer merge conflicts.
+6. **EPIC-008** independent track — can run in parallel with 006/007 once the architecture seam is established.
+
+P3 epics (009, 010) are parked until concrete demand surfaces.
+
+---
+
+## Open Decisions for Lisa
+
+These are architectural decisions Marge is deferring to Lisa:
+
+- **D1 (EPIC-002):** Introduce a `ux.warn/error/progress` helper module, or migrate every `console.print` call site directly?
+- **D2 (EPIC-003):** Final shape of the mutation-result JSON envelope. Marge proposes `{id, type, name, url, next_actions[]}`.
+- **D3 (EPIC-005):** `RunsAPI.list` — paginate by default, or rename `limit` → `page_size` and document the cap?
+- **D4 (EPIC-007):** SDK workflow naming. Verb-based (`trigger`) or noun-based (`trigger_with_queue_management`)?
+- **D5 (EPIC-008):** `LocalIACRunner` base + subclasses, or composition-based runner?

--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ Based on recent Agent-Native CLI design research, the backlog is currently struc
 
 - **PR Batch 3: The Agent Experience (AX) Core** *(In Progress — feat/ax-core)*
   Focus: Eliminating agent "glue logic" (bash pipes, jq, polling loops).
-  Includes: AX1 ✅, AX2 ✅, AX3 ✅, AX4 ✅, AX5 ✅, AX6 ✅.
+  Includes: AX1 ✅, AX2 ✅, AX3 ✅, AX4 ✅, AX5 ✅, AX6 ✅, AX7 (Deep Error Context Surfacing).
 
 - **PR Batch 4: Scripting & Automation Polish** *(In Progress — fix/scripting-polish)*
   Focus: Fixing bugs that break non-interactive shell scripting and automation pipelines.
@@ -788,3 +788,9 @@ These features are specifically designed to reduce the "glue logic" (bash pipes,
 **Success Criteria**:
 - `terrapyne workspace create my-ws --ignore-exists` succeeds (or exits gracefully without a fatal error) if the workspace is already provisioned.
 
+### AX7 — Deep Error Context Surfacing
+**Context**: When a CLI command fails, it often prints a high-level error (e.g. `Status: ❌ errored` or `API Error (422)`) and exits `1`. For an AI agent, this is a dead end. The agent must re-run the command with `--debug` or issue a new command (`run errors <id>`) to discover why it failed, bloating context windows and risking hallucination.
+**Fix**: Update `@handle_cli_errors` to automatically extract and print the detailed JSON `errors` payload from TFCAPIError responses. Additionally, update `run_trigger` and `run_watch` to automatically fetch and print `get_error_summary()` upon terminal run failure before exiting `1`.
+**Success Criteria**:
+- API failures (e.g. `workspace create` with a duplicate name) explicitly print the `title` and `detail` of the TFC JSON error.
+- Wait loops (`run trigger --wait`) automatically print the Terraform error block if the run hits an errored state.

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -6,6 +6,8 @@ How-to guides are problem-oriented. They provide recipes and step-by-step instru
 
 Detailed conventions for contributing to the Terrapyne codebase.
 
+- **[Agent Workflow](agent-workflow.md)** — The strict BDD/TDD cycle, ACP, and mandatory adversarial review for agents working in this repo.
+- **[Epic Handoff](epic-handoff.md)** — How epics move from Marge to Lisa to Ralph; the `TODO-{td-id}.md` format.
 - **[Python & Testing](python-and-testing.md)** — Type hints, imports, test structure, and pytest-bdd patterns.
 - **[Commits & Review](commits-and-review.md)** — Atomic commits, conventional formats, and our PR workflow.
 - **[BDD Specifications](../explanation/bdd-specifications.md)** — Writing Adzic-aligned feature files and step definitions.

--- a/docs/how-to/epic-handoff.md
+++ b/docs/how-to/epic-handoff.md
@@ -1,0 +1,245 @@
+# Epic Handoff
+
+How an Epic moves from Marge (intent) through Lisa (architecture) to Ralph (execution) to Bart (review). The handoff artifact is `TODO-{td-id}.md`. This document defines its format.
+
+## Why a fixed format
+
+Each agent has a different reading lens. Marge cares about user value; Lisa cares about architecture; Ralph cares about constraints; Bart cares about contracts. A single shared file with predictable sections lets each agent find their lens quickly without wading through everything.
+
+The format is **intentionally short**. If the file is more than ~150 lines, decompose the epic.
+
+## When the file is created
+
+| Step | Who | Action |
+| ---- | --- | ------ |
+| 1 | Marge | Adds `## EPIC-XXX` to `PLAN.md`. Logs `td epic create`, captures the ID. |
+| 2 | Marge | Logs `td log <epic-id> --decision "marge_approved"`. |
+| 3 | Lisa | Reads the epic from `PLAN.md`. Runs ToT to pick an architectural approach. |
+| 4 | Lisa | **Creates `TODO-{td-id}.md`** in the repo root. This is the handoff artifact. |
+| 5 | Lisa | Logs `td log <epic-id> --decision "lisa_handoff: <hypothesis-name>"`. |
+| 6 | Ralph | Reads `TODO-{td-id}.md` once at session start. **Does not modify it.** |
+| 7 | Ralph | Decomposes into `td` tasks (per `docs/standards/task-decomposition.md`). |
+| 8 | Bart | Reviews against the constraints in `TODO-{td-id}.md`. |
+
+`TODO-{td-id}.md` is **read-once context**, not a task list. Tasks live in `td`.
+
+## Where the file lives
+
+```
+<repo-root>/TODO-{td-id}.md
+```
+
+One file per active epic. When the epic merges, the file is **deleted** (not archived) — the durable artifact is `PLAN.md` plus the merged commits plus the ADRs Lisa drafted, not the handoff scratch file.
+
+`.gitignore` does **not** exclude `TODO-{td-id}.md`. The file is committed during the epic's life so cross-session agents can read it.
+
+## The format
+
+```markdown
+# TODO-{td-id} — <Epic title>
+
+**Epic:** EPIC-XXX (see `PLAN.md`)
+**Status:** Active
+**Lisa-approved hypothesis:** <one-line summary>
+
+---
+
+## 1. Intent (from Marge)
+
+> Pasted directly from `PLAN.md`. Do not rewrite — this is the immutable contract.
+
+### Problem Statement
+
+<copied from PLAN.md>
+
+### User Value
+
+<copied from PLAN.md>
+
+### Acceptance Criteria
+
+<copied — pointer to the .feature file is fine>
+
+See `tests/features/<file>.feature`.
+
+---
+
+## 2. Context & Constraints (from Lisa)
+
+### Architectural hypothesis
+
+<2-3 sentences naming the chosen approach. e.g. "Add a tiny ux helper module exposing warn/error/progress that wrap error_console. Migrate cli/* to use it; do not change error_console behaviour itself.">
+
+### Why this approach over alternatives
+
+<3-5 bullet points. Reference rejected approaches.>
+
+- Considered <X>; rejected because <reason>.
+- Considered <Y>; rejected because <reason>.
+
+### Relevant ADRs
+
+- ADR-NNN — <title> — relevant because <reason>
+- (if a new ADR is needed) **Proposed: ADR-NNN — <title>** — drafting in `docs/explanation/architecture/ADR-NNN-<slug>.md`
+
+### Tech debt landmines (do NOT touch in this epic)
+
+<Things Lisa knows are wrong but are out of scope. Ralph must avoid them.>
+
+- `cli/utils.py` is a deprecated stub. Do not patch it; do not import from it.
+- `terrapyne.Terraform` deprecation is being handled in a separate epic.
+
+### Quality gates (Ralph must satisfy these)
+
+- [ ] All BDD scenarios in `tests/features/<file>.feature` pass.
+- [ ] No regression in `make test-all`.
+- [ ] No file in `src/` exceeds 500 lines after this epic (or a `refactor:` task is filed).
+- [ ] Farley Index of new tests ≥ 7.0.
+- [ ] Adzic Index of new scenarios ≥ 7.0.
+
+---
+
+## 3. Scope reminders (for Ralph and Bart)
+
+### In scope
+
+<bullet list — be explicit>
+
+### Out of scope
+
+<bullet list — explicit non-goals; prevents scope creep>
+
+### Open questions for Lisa
+
+<If Ralph hits something that breaks the hypothesis, escalate here. Lisa updates this section in place.>
+
+---
+
+## 4. Done definition
+
+The epic is done when:
+
+1. All acceptance scenarios in `tests/features/<file>.feature` pass.
+2. The success metrics in `PLAN.md` for EPIC-XXX are demonstrably met.
+3. Bart has approved the PR.
+4. ADRs in §2 are merged in `Accepted` status (if proposed).
+5. `PLAN.md` epic status is updated to `Done` and the `td` epic is closed.
+6. This file (`TODO-{td-id}.md`) is deleted in the merge commit.
+```
+
+## Worked example
+
+Here's what a real handoff would look like for EPIC-001. (Hypothetical — `td-XXXX` is illustrative.)
+
+```markdown
+# TODO-td-1042 — Restore Test-Suite Repeatability
+
+**Epic:** EPIC-001 (see `PLAN.md`)
+**Status:** Active
+**Lisa-approved hypothesis:** Single autouse fixture that snapshots and restores all six mutable Console fields, plus a structural lint that fails on patches against deprecated stubs.
+
+---
+
+## 1. Intent (from Marge)
+
+### Problem Statement
+
+The test suite reports 815 passing under `make test-all`, but running subsets …
+[copied from PLAN.md]
+
+### Acceptance Criteria
+
+See `tests/features/test_repeatability.feature`.
+
+---
+
+## 2. Context & Constraints (from Lisa)
+
+### Architectural hypothesis
+
+Place an autouse, function-scoped fixture in `tests/conftest.py` that
+snapshots and restores six attributes on the two shared Console instances.
+Ship a one-line fix to the broken `patch()` site at the same time. Do NOT
+refactor the singletons themselves — that's a separate epic (logged to
+TODO.md).
+
+### Why this approach over alternatives
+
+- Considered making `console` a per-test fixture: rejected, would require
+  changing every CLI command's import.
+- Considered `monkeypatch.setattr` per-test: rejected, error-prone, easy
+  to forget.
+- Considered no autouse fixture and a static lint instead: rejected, can't
+  catch runtime mutations cleanly.
+
+### Relevant ADRs
+
+- (No new ADR. Implementation is internal to test infrastructure.)
+
+### Tech debt landmines
+
+- `cli/utils.py` is a deprecated stub. Do not import from it.
+  The broken patch site at `tests/test_cli/test_run_commands.py:1151`
+  must be fixed to point at `terrapyne.cli.run_cmd.validate_context`.
+- `terrapyne.rendering.logging` console singletons are NOT to be refactored
+  in this epic.
+
+### Quality gates
+
+- [ ] `pytest tests/test_cli/` passes alone.
+- [ ] `pytest tests/unit/test_workspace_context.py` passes alone.
+- [ ] Full suite passes after shuffled order (3 seeds).
+- [ ] `make audit-patches` passes.
+
+---
+
+## 3. Scope reminders
+
+### In scope
+
+- `tests/conftest.py` autouse fixture.
+- One-line fix to `tests/test_cli/test_run_commands.py:1151`.
+- `make audit-patches` recipe.
+- `tests/features/test_repeatability.feature`.
+
+### Out of scope
+
+- Refactoring the Console singletons.
+- Adding `pytest-randomly` to dev deps (separate task).
+- Migrating the deprecated `terrapyne.Terraform` import.
+
+### Open questions for Lisa
+
+(none currently)
+
+---
+
+## 4. Done definition
+
+1. All scenarios in `tests/features/test_repeatability.feature` pass.
+2. `pytest tests/test_cli/` and `pytest tests/unit/` both pass alone.
+3. `make audit-patches` is wired into `make test-fast`.
+4. Bart approved.
+5. PLAN.md EPIC-001 → Status: Done.
+6. This file deleted in merge commit.
+```
+
+## Anti-patterns
+
+- **Lisa writes a task list.** No. Tasks come from `td`. The handoff file is *narrative context*. If Lisa is enumerating tasks, she's stealing Ralph's job and the decomposition is no longer co-owned.
+- **Ralph edits §1 or §2.** No. The handoff is immutable from Ralph's perspective. If reality breaks the hypothesis, escalate via §3 ("Open questions for Lisa") and `td log --uncertain`.
+- **Marge edits anything below §1.** No. Marge owns Intent only.
+- **No quality gates.** No. Without explicit gates, "done" becomes a feeling, not a check.
+- **Long handoff file.** A 400-line handoff means the epic is too big. Decompose.
+
+## Self-check before Lisa hands off
+
+```
+[ ] §1 (Intent) is copied verbatim from PLAN.md
+[ ] §2 (Architectural hypothesis) is one paragraph, not a design doc
+[ ] §2 names at least one rejected alternative
+[ ] §2 lists tech debt landmines explicitly
+[ ] Quality gates are concrete and verifiable
+[ ] In/Out of scope are both populated
+[ ] File is < 150 lines
+```

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -16,7 +16,17 @@ Reference documentation is information-oriented. It provides technical specifica
 - **[TFC JSON:API Format](tfc-json-api.md)** *(planned)* — Technical reference for how Terrapyne maps to the HashiCorp TFC JSON:API.
 - **[Terraform State Format](terraform-state-format.md)** *(planned)* — Details on how we parse and represent Terraform state versions.
 
+## 📏 Quality Indices
+
+These are the rubrics agents apply when auditing test and BDD quality. The skills `farley-index` and `adzic-index` score against these documents.
+
+- **[Farley Index](farley-index.md)** — Six properties of good tests: Fast, Maintainable, Repeatable, Atomic, Necessary, Understandable. Target ≥ 7.0 per property.
+- **[Adzic Index](adzic-index.md)** — Six dimensions of BDD quality: Business-Readable, Intention-Revealing, Living, Declarative, Focused, Atomic. Target ≥ 7.0 per dimension.
+
 ## 🛠️ Standards & Compliance
 
+- **[Atomic Commit Protocol](../standards/atomic-commit-protocol.md)** — Rules for what constitutes an atomic, verifiable commit.
+- **[Task Decomposition](../standards/task-decomposition.md)** — INVEST plus named decomposition strategies for breaking epics into tasks.
+- **[Adversarial Review Feedback](../standards/feedback.md)** — The format Bart uses to give feedback to Ralph.
 - **[Versioning Policy](../../CHANGELOG.md)** — How we use Semantic Versioning (SemVer) for the CLI and SDK.
 - **[Engineering Standards](../../AGENTS.md)** — The non-negotiable quality guardrails used to build Terrapyne.

--- a/docs/reference/adzic-index.md
+++ b/docs/reference/adzic-index.md
@@ -1,0 +1,164 @@
+# Adzic Index
+
+Quantitative rubric for evaluating BDD feature files against Gojko Adzic's Specification by Example principles. The companion to the Farley Index.
+
+This document is the in-repo reference for the index. The `adzic-index` skill in your agent toolkit applies it; this file is what the skill scores against.
+
+## Why this exists
+
+Farley measures whether unit tests are trustworthy. Adzic measures whether the BDD layer **communicates the right thing to the right people**.
+
+The question shifts from "do our scenarios pass?" to "do our scenarios describe what the user actually needs, in language the user can read?"
+
+## The six dimensions
+
+| Dimension | Question it answers |
+| --------- | ------------------- |
+| **Business-Readable** | Can a non-technical stakeholder understand this scenario without explanation? |
+| **Intention-Revealing** | Does the scenario describe *why* the system does this? |
+| **Living** | Is every step backed by a real implementation? |
+| **Declarative** | Does the scenario describe *what*, not *how*? |
+| **Focused** | Does each scenario test exactly one behaviour? |
+| **Atomic** | Can scenarios run in any order, with no shared state? |
+
+## Scoring rubric (0-10 per dimension)
+
+Same scoring scale as the Farley Index. The Adzic Index is the arithmetic mean across the six dimensions.
+
+| Score | Meaning |
+| ----- | ------- |
+| 9-10 | Best in class. Could be shown to a stakeholder cold. |
+| 7-8 | Good. Stakeholder-readable with minor jargon. |
+| 5-6 | Workable but degrading; tests behave like UI scripts in places. |
+| 3-4 | Reads as test code wearing Gherkin syntax. |
+| 0-2 | Imperative test steps; no business value. |
+
+**Target for terrapyne: every dimension ≥ 7.0.** Below 7.0 on any dimension is a red flag.
+
+## Per-dimension scoring guide
+
+### Business-Readable
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Reads as plain English. No HTTP verbs, no class names, no SQL. A product manager can validate it. |
+| 7-8 | Mostly readable; occasional domain jargon (`workspace`, `run`, `project`) which is appropriate. |
+| 5-6 | Mixes domain language with implementation terms (`API call`, `JSON response`). |
+| 3-4 | References method names, status codes, internal symbols. |
+| 0-2 | "Given the database row…" / "When the function returns…" |
+
+**Test:** read a scenario aloud to someone who's never seen the code. Did they understand it without you stopping to explain?
+
+### Intention-Revealing
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Every scenario carries the `As a / I want / So that` framing or its meaning. The *why* is visible. |
+| 7-8 | The why is often visible; some scenarios assume context. |
+| 5-6 | Scenario titles describe what the test does, not why the user wants it. |
+| 3-4 | Titles like "Test scenario 1", "Empty input case", "Edge case 4". |
+| 0-2 | Scenarios are anonymous behaviours, no user, no goal. |
+
+**Test:** read only the `Feature` line and the `Scenario` titles. Could a stakeholder pick a scenario based on its title alone?
+
+### Living
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Every scenario in the suite is executable today. Zero `@pending`, zero skipped, zero TODO scenarios. |
+| 7-8 | A handful of `@pending` scenarios with explicit ticket references. |
+| 5-6 | Several `@pending` or `@skip` scenarios; some have been pending for months. |
+| 3-4 | The "documented but not executed" pile is larger than the executed pile. |
+| 0-2 | Feature files are documentation that's never been run. |
+
+**Test:** `grep -r '@pending\|@skip' tests/features/`. The result should be empty or trivially short.
+
+**terrapyne current:** zero `@pending`/`@skip` tags. ✅ 9-10 today.
+
+### Declarative
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Steps describe state and outcome. Never a click, never a keystroke, never an HTTP verb. |
+| 7-8 | Mostly declarative; rare imperatives in `When` steps to set up complex state. |
+| 5-6 | `When I click X, then I press Y, then I wait` patterns. |
+| 3-4 | Scenarios read as Selenium scripts in Gherkin. |
+| 0-2 | Implementation is so leaked that the scenario is locked to one UI. |
+
+**Red flags:** `When I click`, `When I press`, `When I navigate to`, `When I send a POST request`, `When I select from dropdown`.
+
+**terrapyne current:** zero UI-script patterns. ✅ 9-10 today.
+
+### Focused
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Each scenario tests one rule. Given:Then ratio under 3:1. |
+| 7-8 | Most scenarios focused; some "happy path" scenarios bundle related assertions. |
+| 5-6 | Several scenarios test multiple behaviours. Hard to name them precisely. |
+| 3-4 | "Full lifecycle" scenarios that bundle 5+ behaviours. |
+| 0-2 | Scenarios are smoke tests pretending to be specifications. |
+
+**Red flag:** scenario titles containing "and", multiple `Then` steps with unrelated assertions.
+
+### Atomic
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Scenarios share no state. Run order is irrelevant. Every scenario sets up its own context. |
+| 7-8 | `Background:` is used appropriately for shared setup; no hidden coupling. |
+| 5-6 | Some scenarios depend on side effects of earlier scenarios. |
+| 3-4 | Suite has a "must run in this order" property. |
+| 0-2 | Scenario coupling is so deep that re-ordering breaks the suite. |
+
+**Red flag:** scenarios that pass alone but fail together (or vice versa).
+
+## Applying the index in this repo
+
+### When Marge runs it
+
+Before handing a feature brief to Lisa, Marge audits her own scenarios:
+
+```bash
+# Use the adzic-index skill, or:
+grep -rn "click\|press\|navigate" tests/features/         # UI-script red flag
+grep -rn "@pending\|@skip" tests/features/                # Living red flag
+grep -rn "API\|HTTP\|status code" tests/features/         # Implementation leak
+```
+
+Marge focuses on Business-Readable and Intention-Revealing — those are her dimensions.
+
+### When Ralph runs it
+
+When writing step definitions, Ralph audits Declarative and Living: every Gherkin step must have a real implementation, and the implementation must verify the *outcome*, not the implementation path.
+
+### When Bart runs it
+
+During review, Bart spot-checks Focused (no scenario doing too much) and Atomic (no order coupling). If Bart finds a coupled scenario, that's a `MINOR` finding unless it actually causes flakes (then `BLOCKER`).
+
+## Where this index currently lands
+
+Based on the May 2026 audit (see solution review notes):
+
+| Dimension | Score | Notes |
+| --------- | ----- | ----- |
+| Business-Readable | 8 | Domain language used appropriately; no HTTP/class jargon |
+| Intention-Revealing | 8 | `As a / I want / So that` framing throughout |
+| Living | 9 | Zero `@pending`, zero skipped scenarios |
+| Declarative | 9 | No UI-script patterns anywhere |
+| Focused | 7 | `workspace.feature` (266 lines) is too broad — split underway |
+| Atomic | 7 | Mostly atomic; the order-dependence issue is at the Farley layer (console singleton), not at the BDD layer |
+| **Index** | **8.0** | Strong overall; weakness is concentrated in Focused |
+
+## Scoring traps
+
+- **Don't grade Living high just because tests pass.** A passing test that's coupled to implementation can be both Living = 9 and Declarative = 3. Score them independently.
+- **`Background:` does not lower Atomic.** Used appropriately, it's the canonical way to share setup. It only lowers Atomic when scenarios depend on it implicitly via global state.
+- **Domain jargon is allowed.** "Workspace" and "run" are domain terms in TFC; they're Business-Readable for the right audience. "API request" and "POST" are not.
+
+## References
+
+- Gojko Adzic, *Specification by Example* (2011).
+- Skill: `adzic-index` (in agent toolkit).
+- Companion: `docs/reference/farley-index.md` (TDD-layer rubric).
+- Internal: `docs/explanation/bdd-specifications.md` (how-to for writing scenarios).

--- a/docs/reference/farley-index.md
+++ b/docs/reference/farley-index.md
@@ -1,0 +1,174 @@
+# Farley Index
+
+Quantitative rubric for evaluating the test suite against Dave Farley's six properties of good tests. Cited from the Ralph and Bart agent personas.
+
+This document is the in-repo reference for the index. The `farley-index` skill in your agent toolkit applies it; this file is what the skill scores against.
+
+## The six properties
+
+| Property | Question it answers |
+| -------- | ------------------- |
+| **Fast** | Does the suite give feedback in seconds, not minutes? |
+| **Maintainable** | Can I refactor production code without rewriting half the tests? |
+| **Repeatable** | Does the suite produce the same result every run, on every machine, in any order? |
+| **Atomic** | Does each test verify exactly one behaviour? |
+| **Necessary** | Is each test demanded by a real requirement? |
+| **Understandable** | Can a new contributor read a failure and know what's broken? |
+
+The properties are not independent. A test that's not Repeatable will eventually look not Maintainable (because of the workarounds). A test that's not Atomic is hard to make Understandable.
+
+## Scoring rubric (0-10 per property)
+
+Each property is scored 0-10. The Farley Index is the **arithmetic mean**, not the minimum — because real suites have known weak spots and we want to track movement over time, not pass/fail.
+
+| Score | Meaning |
+| ----- | ------- |
+| 9-10 | Best in class. Worth holding up as an example. |
+| 7-8 | Good. Trustworthy. The default target. |
+| 5-6 | Workable but degrading. Plan a remediation epic. |
+| 3-4 | Hurting velocity. Block major new work until improved. |
+| 0-2 | Actively misleading. The signal is worse than no signal. |
+
+**Target for terrapyne: every property ≥ 7.0.** Below 7.0 on any property is a red flag.
+
+## Per-property scoring guide
+
+### Fast
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Inner loop < 5s, full suite < 30s, no test > 100ms unless explicitly marked `@pytest.mark.slow` |
+| 7-8 | Inner loop < 10s, full suite < 60s, occasional outliers documented |
+| 5-6 | Full suite > 60s, several tests doing real I/O without justification |
+| 3-4 | Full suite > 5 minutes, agents avoid running it locally |
+| 0-2 | Full suite is "the CI-only suite" |
+
+**Red flags:** real `httpx.Client` calls in unit tests, `time.sleep()` without `patch("time.sleep")`, `subprocess.run(["terraform", ...])` without `pytest.mark.slow`.
+
+**Tools:** `pytest --durations=10` shows the slowest tests.
+
+### Maintainable
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Tests assert on observable behaviour through public APIs. Renaming an internal symbol breaks zero tests. |
+| 7-8 | Most tests behaviour-focused. A handful poke at internals but they're flagged. |
+| 5-6 | A non-trivial fraction of tests reference private symbols or specific log lines. |
+| 3-4 | Refactoring routinely requires updating dozens of tests with no behaviour change. |
+| 0-2 | Mock Tautology — tests verify the mock was called with what the test set up; no real coverage. |
+
+**Red flags:** tests that fail when a private method is renamed, tests that assert on log strings, tests that mock the same module they're testing.
+
+**The Mock Tautology check:** read the test. If you can answer "what bug would this catch?" with "none — it just verifies the mock returns what I told it to", the test is mock-tautological.
+
+### Repeatable
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Suite passes in any order, any seed, on any machine, every time. Verified by CI running shuffled orderings. |
+| 7-8 | Order-independent in practice; no known flakies. |
+| 5-6 | Occasional flakes blamed on "the network" or "CI being slow". |
+| 3-4 | Subset runs produce different results from full runs. (← terrapyne is currently here.) |
+| 0-2 | The suite has private knowledge of execution order. Cannot be parallelised. |
+
+**Red flags:** module-level state mutated by tests but not reset (singletons, environment variables, log handlers, monkey-patches), `os.environ` mutations, file system writes without `tmp_path`, current-time dependencies without `freezegun` or equivalent.
+
+**Verification:** run subsets and full suite and compare results. CI should do this on every PR.
+
+### Atomic
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Each test verifies one behaviour. Setup-to-assertion ratio < 3:1. A failure name tells you the bug. |
+| 7-8 | Most tests atomic. A few "happy path + smoke check" tests acknowledged. |
+| 5-6 | Several tests verify multiple behaviours. Failures require re-reading the test to understand which assertion fired. |
+| 3-4 | Common pattern: 50-line setup, 10 unrelated assertions, "test_workspace_full_lifecycle". |
+| 0-2 | One test class per file, one method per class, hundreds of lines of mixed concerns. |
+
+**Red flag:** tests with multiple `assert` statements covering unrelated behaviours.
+
+**The "what failed?" check:** read a test name. If it doesn't tell you what bug a failure represents, it's not atomic.
+
+### Necessary
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Every test demanded by a real requirement (BDD scenario, bug regression, public API contract). Removing any test creates a real coverage gap. |
+| 7-8 | Most tests necessary. A few coverage-chasers acknowledged. |
+| 5-6 | A noticeable number of tests duplicate other tests with different inputs but same behaviour. |
+| 3-4 | Coverage-game tests. Lots of `def test_init_works():` style. |
+| 0-2 | The suite exists to satisfy `--cov-fail-under`, not to verify correctness. |
+
+**Red flag:** tests that exist only to push coverage; tests for getter/setter behaviour on Pydantic models; tests that re-test the framework rather than the code.
+
+**The bug-regression check:** if a test failed, would there be a real user-visible bug? If not, the test is decorative.
+
+### Understandable
+
+| Score | What it looks like |
+| ----- | ------------------ |
+| 9-10 | Test names describe behaviour. Arrange/Act/Assert is visually obvious. Magic literals are named. A new contributor can read any test cold. |
+| 7-8 | Most tests clear. A few helper-heavy tests need a second read. |
+| 5-6 | Tests pass but you have to re-read them to understand what they do. |
+| 3-4 | Test names like `test_function_one`, magic numbers, helpers stacked five deep. |
+| 0-2 | Failures are mysteries. Debugging a flake takes longer than fixing the bug. |
+
+**Red flag:** test names that describe mechanics (`test_calculate_returns_value`) instead of behaviour (`user_cannot_checkout_with_empty_basket`).
+
+**The "name tells the story" check:** read only the test name. Can you predict what it asserts? If not, rename it.
+
+## Applying the index in this repo
+
+### When Ralph runs it
+
+Before raising a PR (the pre-PR self-audit in the Ralph persona):
+
+```bash
+# Use the farley-index skill, or:
+pytest --durations=10                       # Fast check
+pytest tests/                                # Full pass
+pytest tests/ --shuffle  # if pytest-randomly installed
+```
+
+Score each property, focus on `Fast` and `Necessary` (Ralph's primary concerns), file MINOR findings on others as observations.
+
+### When Bart runs it
+
+During adversarial review:
+
+```bash
+# Same commands, but Bart focuses on Maintainable and Repeatable
+# because those are the properties that catch problems CI misses.
+```
+
+### When Lisa reads it
+
+Lisa consumes Bart's Retrospective Signal, which includes a Farley score breakdown. Lisa uses it to decide whether the next epic should include test-debt remediation as a foundational task.
+
+## Where this index currently lands
+
+Based on the May 2026 audit (see `PLAN.md` EPIC-001):
+
+| Property | Score | Notes |
+| -------- | ----- | ----- |
+| Fast | 9 | `make test-fast` ~5s, full suite ~28s |
+| Maintainable | 7 | Heavy MagicMock use is appropriate for an HTTP wrapper; some BDD steps assert on output strings (mild Maintainable risk) |
+| Repeatable | 4 | Order-dependent failures via console singleton; broken `patch()` site |
+| Atomic | 7 | Most tests atomic; some BDD scenarios share fixtures across When/Then in ways that couple steps |
+| Necessary | 8 | 84% coverage with 815 tests; clearly calibrated to real behaviour |
+| Understandable | 8 | Test names describe behaviour; BDD scenarios read as specs |
+| **Index** | **7.2** | Held back almost entirely by Repeatable |
+
+EPIC-001 is the remediation. Once landed, Repeatable should rise to 8-9 and the Index to ~7.8.
+
+## Scoring traps
+
+- **Don't average down rare extreme scores.** A single 2 in Repeatable matters more than three 8s. Note it explicitly.
+- **Don't rely on coverage as a Necessary proxy.** 95% coverage of trivial getters has Necessary = 3. 70% coverage of behaviour has Necessary = 9.
+- **Don't conflate Fast with cheap.** A 50ms test that hits real S3 is fast — but not Repeatable.
+
+## References
+
+- Dave Farley, *Modern Software Engineering* (2021), Chapters 8-10.
+- Skill: `farley-index` (in agent toolkit).
+- Companion: `docs/reference/adzic-index.md` (BDD-layer rubric).

--- a/docs/standards/atomic-commit-protocol.md
+++ b/docs/standards/atomic-commit-protocol.md
@@ -1,0 +1,182 @@
+# Atomic Commit Protocol (ACP)
+
+Canonical definition. Cited from `docs/how-to/agent-workflow.md`, `docs/how-to/commits-and-review.md`, and the Ralph agent persona.
+
+## What "atomic" means here
+
+A commit is **atomic** when:
+
+1. **One reason to change.** The commit addresses exactly one concern. If the commit message needs the word "and" twice, split it.
+2. **Self-contained.** The commit reverts cleanly. No partial state, no orphaned imports, no half-renamed symbols.
+3. **Verified.** The commit was created from a working tree that passes the verification suite.
+4. **Documented.** The commit message explains *why*, not what. The diff shows what.
+
+Commits that match this definition can be reordered, cherry-picked, reverted, and read in isolation 18 months from now. Commits that don't match it become technical debt the moment they land.
+
+## The verification gate
+
+Before any commit lands, this must pass locally:
+
+```bash
+make test-fast    # ruff + import-linter + mypy + ruff-lint
+make test-all     # full pytest suite
+```
+
+If `make test-fast` fails, the commit is not safe to make. If `make test-all` fails, the commit is not safe to push. There is no shortcut.
+
+For agents using the `commit` skill, the skill runs this gate. Do not bypass it with `--no-verify`.
+
+## Conventional Commits format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**`<type>`** — exactly one of:
+
+| Type | When |
+| ---- | ---- |
+| `feat` | New user-facing capability |
+| `fix` | Bug fix that affects users |
+| `docs` | Documentation only — no code change |
+| `test` | Test-only changes — no production code |
+| `refactor` | Internal restructuring with no behaviour change |
+| `chore` | Build, dependencies, tooling; nothing that ships to users |
+| `perf` | Performance improvement (use sparingly; needs measurement) |
+
+Append `!` for breaking changes (`feat!:`, `fix!:`).
+
+**`<scope>`** — optional but encouraged. Use the affected module: `workspace-cmd`, `runs-api`, `plan-parser`, `cli`, `models`. Lowercase, hyphenated, singular.
+
+**`<subject>`** — imperative, present tense, lowercase, no trailing period, ≤ 50 characters.
+
+| Good | Bad |
+| ---- | --- |
+| `feat(workspace-cmd): add --no-truncate flag` | `Added --no-truncate flag.` |
+| `fix(runs-api): paginate beyond 100 runs` | `Fixed pagination` |
+| `refactor(cli): split run_cmd into per-command files` | `WIP cli refactor` |
+
+## Commit body — the *why*
+
+The diff already shows what changed. The body explains *why this change matters now* and *what alternatives were rejected*.
+
+A good body answers three questions:
+
+1. What problem does this solve?
+2. Why this approach over the obvious alternative?
+3. What would break if I reverted this commit?
+
+Three short paragraphs is usually enough. Reference issues, ADRs, and EPIC IDs in the footer.
+
+```
+fix(runs-api): paginate beyond 100 runs
+
+RunsAPI.list silently truncated at 100 because it issued a single page
+request rather than using client.paginate. A user passing limit=500 had
+no way to see the truncation — the SDK promise of "high-level
+abstractions" was broken.
+
+This delegates to client.paginate, which already does this correctly for
+WorkspaceAPI.list. The asymmetry is removed and the limit parameter now
+behaves as named.
+
+Closes EPIC-005
+Refs ADR-003 (API include parameters)
+```
+
+## Atomicity in practice
+
+### Splitting before committing
+
+If you have unrelated changes in your working tree:
+
+```bash
+git add -p <file>          # stage only the relevant hunks
+git commit -m "feat(...): ..."
+git stash                  # stash the rest
+# next session: git stash pop, repeat
+```
+
+Or:
+
+```bash
+git add tests/test_foo.py src/foo.py        # one concern
+git commit -m "feat(foo): ..."
+git add tests/test_bar.py src/bar.py        # different concern
+git commit -m "fix(bar): ..."
+```
+
+### Tests + production code in the same commit
+
+Tests and the production code they exercise belong **in the same commit**. A test commit followed by an implementation commit produces a CI-failing intermediate state — not atomic.
+
+Exception: when adding tests against existing production code (no production change), commit them alone with `test(...):`. Mark whether they cover an existing bug (`test: cover regression in plan parser`) or just close a coverage gap.
+
+### Refactor commits
+
+A `refactor(...):` commit must be behaviourally indistinguishable from its parent. If `make test-all` would have produced different results before and after the commit, it's not a refactor — it's a `feat` or `fix`.
+
+The clean signal: a refactor commit can be dropped from a series and the user-visible behaviour is identical to the resulting tree.
+
+## Two-step "Green then Refactor" pattern
+
+The Red-Green-Refactor TDD cycle maps to two commits, in order:
+
+1. **Green commit.** Tests pass, code may be ugly. Commit the messy-but-correct state.
+2. **Refactor commit.** Same tests pass, code is clean. Commit the polish.
+
+Do **not** combine them. The Green commit is the safety net; the Refactor commit is the cleanup. Keeping them separate makes each easy to review and easy to revert.
+
+## What to never put in a commit message
+
+- AI markers — no `Co-Authored-By: Claude`, no `Generated with`, no agent attribution. The repo is enforcing this; `make audit-ai-markers` will fail the push.
+- Trailing periods on the subject line.
+- Past tense (`Added X`, `Fixed Y`). Imperative only.
+- The string "WIP" — work-in-progress doesn't belong in `main`. If you need to checkpoint, branch.
+- Bug numbers without context (`fix #42`). Include enough subject text that the message is readable without resolving the link.
+
+## Footer fields
+
+| Field | When | Format |
+| ----- | ---- | ------ |
+| `Closes` | Issue / EPIC fully resolved by this commit | `Closes #42`, `Closes EPIC-001` |
+| `Refs` | Related but not closed | `Refs ADR-005` |
+| `Co-Authored-By` | Real human collaborator | `Co-Authored-By: Name <email>` (NOT for agents) |
+| `BREAKING CHANGE` | Required for `feat!:`/`fix!:` | One paragraph describing migration |
+
+## When you mess up
+
+You will mess up. The recovery patterns:
+
+```bash
+# Last commit was wrong; not pushed yet
+git commit --amend            # for message-only fixes
+git reset --soft HEAD~1       # to re-stage and re-commit
+
+# Last commit was wrong; already pushed
+git revert <sha>              # never force-push to a shared branch
+
+# Series of commits is wrong; not pushed
+git rebase -i origin/main     # squash / split / reorder
+
+# Series of commits is wrong; pushed
+# Stop. Open a new branch with the corrections. Don't rewrite shared history.
+```
+
+## Self-check before committing
+
+```
+[ ] Subject ≤ 50 chars, imperative, no period
+[ ] Body explains why, not what
+[ ] One reason to change (no "and" twice)
+[ ] make test-fast passes
+[ ] make test-all passes
+[ ] No AI markers anywhere
+[ ] No new TODO without a ticket reference
+```
+
+If any box is unchecked, fix it before `git commit`.

--- a/docs/standards/feedback.md
+++ b/docs/standards/feedback.md
@@ -1,0 +1,138 @@
+# Adversarial Review Feedback
+
+The format Bart uses to give feedback to Ralph. Cited from the Bart agent persona.
+
+## Why a fixed format
+
+Adversarial review without a format degrades into either rubber-stamping or destructive nitpicking. The format makes Bart's feedback **actionable**, **prioritised**, and **bounded** — Ralph can fix what's blocking and park what's not.
+
+The format also enforces JBGE (Just Barely Good Enough): if Bart cannot articulate the *risk* a finding poses, the finding doesn't block merge.
+
+## Two artifacts, one review
+
+Bart produces two outputs per review:
+
+1. **`FEEDBACK.md`** — produced **only when the PR is rejected**. Tactical, for Ralph. Lives in the worktree alongside the PR (e.g. `.worktrees/<branch>/FEEDBACK.md`).
+
+2. **Retrospective Signal** — produced **always**, for Lisa. Goes to `td log <epic-id> --decision` as a structured payload. Lisa reads it before planning the next epic.
+
+This document defines the `FEEDBACK.md` format. The Retrospective Signal format is in `docs/standards/retrospective-signal.md` (TODO).
+
+## FEEDBACK.md template
+
+```markdown
+# Review Feedback — <PR title or branch name>
+
+**Reviewer:** Bart
+**Date:** YYYY-MM-DD
+**Verdict:** REJECTED | CHANGES_REQUESTED
+**Source:** <PR URL, or path to worktree>
+
+## Summary
+
+<One paragraph. What did Ralph build? What's the headline reason this isn't ready?>
+
+## Blocking findings
+
+<Required to fix before merge. Each finding follows the What/Why/How/Priority pattern below.>
+
+### B1. <Short title>
+
+**What:** <One sentence describing the issue. Cite file and line.>
+
+**Why:** <The risk. Security, correctness, performance, contract violation. Be specific — "this could break" is not a reason; "this leaks the API token to stderr in debug mode" is.>
+
+**How:** <Concrete fix. Point to the pattern Ralph should follow if one exists in the repo.>
+
+**Priority:** BLOCKER | CRITICAL
+
+### B2. <Next blocking finding…>
+
+…
+
+## Non-blocking findings
+
+<Useful to fix but not gating merge. These are minor or "nice to haves". Ralph should park them in TODO.md if they're worth doing later.>
+
+### N1. <Short title>
+
+**What:** …
+**Why:** …
+**How:** …
+**Priority:** MINOR | NIT
+
+## Tests Bart ran
+
+<What did Bart actually verify, beyond CI? Real adversarial review means running the code with weird inputs, not just reading the diff.>
+
+- [ ] Ran `make test-all` after pulling the branch
+- [ ] Tried <specific edge case 1>
+- [ ] Tried <specific edge case 2>
+- [ ] Read the BDD scenarios for coupling to implementation
+
+## Architectural notes (for Lisa)
+
+<Anything Bart noticed that's not Ralph's fault but Lisa needs to know about. Tech debt surfaced. ADR assumptions that didn't hold. Constraints that need adjusting before the next epic.>
+```
+
+## Priority semantics
+
+| Priority | When | Effect |
+| -------- | ---- | ------ |
+| `BLOCKER` | Security, data loss, correctness, contract violation | PR cannot merge |
+| `CRITICAL` | High-likelihood bug under realistic conditions | PR cannot merge |
+| `MINOR` | Code quality, future maintenance burden | PR can merge; park in `TODO.md` |
+| `NIT` | Style, naming preference | PR can merge; do not park; let it go |
+
+If Bart finds himself classifying half the findings as `BLOCKER`, he is over-blocking. Re-read the design philosophy and JBGE principle in the agent persona.
+
+## What/Why/How/Priority — the four-field rule
+
+Every finding must have all four fields. If Bart can't fill in a field, the finding isn't ready to deliver.
+
+| Field | Bad | Good |
+| ----- | --- | ---- |
+| **What** | "There's a bug in workspaces.py" | "`workspaces.py:142` calls `get_organization()` without checking the return — passes `None` to `f-string`." |
+| **Why** | "It might fail" | "If the user omits `--organization` and no env var is set, the CLI prints `No workspaces in None` instead of a usable error message. Breaks our 'errors must be actionable' contract." |
+| **How** | "Fix the bug" | "Use `validate_context()` from `cli/context_helpers.py` — same pattern as `workspace list`. Or raise `ValueError` and let `handle_cli_errors` format it." |
+| **Priority** | (omitted) | `BLOCKER` (contract violation) / `MINOR` (cosmetic) |
+
+## What Bart does NOT do
+
+- **Style preferences.** Black/Ruff/MyPy already enforce style. If Bart finds himself debating naming, he stops and either lets it go (NIT) or files a `chore` task to update the lint config.
+- **Architectural rewrites the PR didn't propose.** If Bart wants a different architecture, that's a separate epic via Lisa, not feedback on this PR.
+- **Tone-policing the commit messages.** If commits violate ACP, file a single finding pointing to `docs/standards/atomic-commit-protocol.md`. Don't repeat it per commit.
+- **Re-running the work.** If Bart is rewriting the code in his head, that's not review — that's redoing. Stop, document the gap, hand back.
+
+## Constructive vs destructive — examples
+
+### Destructive (do not write)
+
+> "This is terrible. You hardcoded the timeout. Fix it."
+
+### Constructive (write this)
+
+> **B1. Hardcoded timeout in `runs.py:218`**
+>
+> **What:** `time.sleep(30)` after a 503 response. Hardcoded.
+>
+> **Why:** Slow networks (e.g. CI runners on US-East talking to TFC EU) regularly take >30s to recover. We've seen this on PR #92. The retry will give up before the rate limit lifts.
+>
+> **How:** Use `tenacity.wait_exponential` like the rest of `client.py`. The pattern is in `_request()` lines 198-205.
+>
+> **Priority:** CRITICAL
+
+The constructive version is the same length but it teaches.
+
+## Self-check before delivering FEEDBACK.md
+
+```
+[ ] Every finding has all four fields filled
+[ ] Blockers are genuinely blocking (security, correctness, contract)
+[ ] At least one of the "Tests Bart ran" boxes is ticked
+[ ] No style-only findings escalated above NIT
+[ ] Architectural notes are separated from tactical findings
+[ ] Tone is constructive throughout
+```
+
+If any box is unchecked, the review is not ready to deliver.

--- a/docs/standards/task-decomposition.md
+++ b/docs/standards/task-decomposition.md
@@ -1,0 +1,138 @@
+# Task Decomposition
+
+How an Epic becomes a sequence of testable, independently-shippable tasks. Cited from the Ralph agent persona.
+
+## Where this fits
+
+Marge writes the `EPIC-XXX` in `PLAN.md`. Lisa hands Ralph a `TODO-{td-id}.md` context file (see `docs/how-to/epic-handoff.md`). Ralph decomposes the epic into `td` tasks **once**, at the start of his first session on that epic, and logs the decomposition decision so future sessions inherit it.
+
+This document defines the rules for that decomposition.
+
+## INVEST
+
+Each task must be:
+
+| Letter | Means | Test |
+| ------ | ----- | ---- |
+| **I**ndependent | Has no hard dependency on a sibling task | Could be picked up first or last |
+| **N**egotiable | The "how" is not yet locked in | Reads as a behaviour, not a checklist |
+| **V**aluable | Delivers something a reviewer can verify | A reviewer can write a one-line test plan |
+| **E**stimable | Effort is roughly knowable | "Half a day" or "an afternoon" — not "a week" |
+| **S**mall | Fits in one focused session | One or two ACP commits, max |
+| **T**estable | Has a Red test before any Green code | The Red test is the first artifact |
+
+If a task fails any letter, decompose further or merge with a sibling.
+
+## Decomposition strategies
+
+Pick the cut that exposes the most risk first. Strategies in roughly ascending complexity:
+
+### Strategy 1 — Happy path → error paths
+
+Cut the work into:
+
+1. The simplest success scenario (one user, one input, one output).
+2. Each error path as a separate task.
+
+Use when the success path is clear but the error envelope is fuzzy. Common for new commands, new SDK methods.
+
+**Example (EPIC-003 / `run trigger --format json`):**
+- Task 1: Successful trigger emits `{id, type, name, url, next_actions}`.
+- Task 2: Trigger against missing workspace emits `{error}` with non-zero exit.
+- Task 3: Trigger blocked by active run emits `{error, blocking_run_id}`.
+
+### Strategy 2 — Boundary first
+
+Cut along the architectural seam. Build the boundary class/method/contract first with a minimal pass-through, then layer behaviour onto it.
+
+Use when the epic introduces a new architectural seam (a new SDK method, a new CLI subgroup).
+
+**Example (EPIC-008 / OpenTofu):**
+- Task 1: `LocalIACRunner` base class with `Terraform` subclass that's behaviourally equivalent to today's `Terraform`.
+- Task 2: `OpenTofu` subclass that delegates to `tofu` binary.
+- Task 3: `detect_runner()` factory using `.terraform.lock.hcl` heuristic.
+- Task 4: TFC-API blocking guard for OpenTofu projects.
+
+### Strategy 3 — Data variation
+
+Same operation, different shapes of input. Each shape is a task; each gets its own scenario.
+
+Use for parsers, formatters, validators.
+
+**Example (existing plan parser):**
+- Task 1: Parse a basic create-only plan.
+- Task 2: Parse a plan with destroys.
+- Task 3: Parse a plan with imports.
+- Task 4: Parse a plan with module-nested resources.
+
+### Strategy 4 — Layer by layer
+
+Cut along the layering boundary: model → API → CLI. Each layer is a task and the inner-loop test for that layer is the gate.
+
+Use when the change spans the full stack and the model layer is the riskiest part.
+
+**Example (EPIC-007 / push orchestration to SDK):**
+- Task 1: `RunsAPI.trigger(queue_strategy=...)` SDK method with unit tests.
+- Task 2: CLI `run trigger` command body shrinks to ~30 lines using new SDK method.
+- Task 3: Documentation update (`docs/reference/sdk.md`).
+
+### Strategy 5 — Refactor as the first task
+
+For epics where messy existing code blocks clean addition, the first task is a **pure refactor** (no behavioural change), and subsequent tasks add the new behaviour onto the refactored shape.
+
+Use when the existing code is a hub or has known structural problems (EPIC-006).
+
+**Example (EPIC-006 / split CLI command modules):**
+- Task 1: Move `run list`, `run show` into their own files. No behaviour change. Full suite passes.
+- Task 2: Move `run trigger`, `run watch`. Same gate.
+- Task 3: Move `run follow`, `run logs`. Same gate.
+- Task 4: Move remaining `run` commands; `run_cmd.py` becomes only a re-export.
+
+The `refactor:` commits in this strategy are valuable precisely because they introduce no risk of behavioural regression.
+
+## Sequencing the tasks
+
+Once decomposed, sequence by **risk-first, dependency-aware**:
+
+1. **Foundational boundary first.** If a task introduces a new seam, the next task can use it. Get the seam right before piling onto it.
+2. **Happy path before error paths.** Error handling without a success path is testing a vacuum.
+3. **Risky/unknown before well-understood.** If you suspect a task may surface an "Option Viability Failure" (Lisa's architecture won't survive contact with reality), do that task first. A failure on Task 1 lets Lisa replan cheaply; a failure on Task 5 wastes Tasks 2-4.
+
+Encode dependencies as explicit `td dep add` links between tasks.
+
+## When decomposition is wrong
+
+You'll know decomposition is wrong if:
+
+- You write a Green commit that doesn't deliver a reviewable behaviour change → tasks too small / too coupled.
+- You can't write the Red test until the next task lands → tasks have hidden dependencies; merge or reorder.
+- You finish the epic and realise tasks should have been one task → over-decomposed; note the lesson in the Retrospective Signal.
+- You finish a task and three more pop into existence → underdecomposed; pause, expand the task list before pushing on.
+
+## Logging the decomposition
+
+After decomposing, log the decision so future sessions don't redo it:
+
+```bash
+td log <epic-id> --decision \
+  "decomposed by [strategy-name] — [one-sentence rationale]"
+```
+
+Future sessions read this with `td show <epic-id>` and inherit the decomposition intent rather than reinventing it.
+
+## Anti-patterns
+
+- **"Implement X" tasks.** Verb without behaviour. Decompose further.
+- **"Write tests for X" as a separate task from "Build X".** Tests and production code ship together (ACP). The tests are part of the build task, not a sibling of it.
+- **"Refactor + new feature in one task".** Refactor is its own task with its own commit (Green-then-Refactor split, or Strategy 5).
+- **Tasks with sibling order coupling.** Task 2 cannot start until Task 1 ships *and* the file structure of Task 1 is preserved → these are one task, not two.
+
+## Self-check after decomposing
+
+```
+[ ] Each task could be picked up by a different agent
+[ ] Each task has a Red test as its first deliverable
+[ ] No task takes more than two ACP commits
+[ ] Sequencing puts risk first
+[ ] The decomposition strategy is logged via td log --decision
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,12 +181,52 @@ def pytest_configure(config):
 
 @pytest.fixture(autouse=True)
 def setup_console():
-    """Ensure Rich console uses a clean instance for every test."""
+    """Snapshot and restore the shared Rich console singletons around every test.
+
+    The singletons ``terrapyne.rendering.logging.console`` and ``error_console``
+    carry mutable state (``quiet``, ``_force_terminal``, ``no_color``, ``_width``)
+    that production code and other tests legitimately mutate via ``set_console``,
+    ``set_quiet_mode``, and ``configure_for_agent_context``.
+
+    Without restoration, mutations leak across tests and produce order-dependent
+    failures (one test sets ``console.quiet = True``; the next test sees a quiet
+    console and fails an output assertion). See EPIC-001 in PLAN.md.
+
+    This fixture:
+    1. Snapshots the six relevant attributes on both consoles.
+    2. Configures a fresh forced-terminal console for the test (matches the
+       behaviour the previous version of this fixture provided).
+    3. Restores the snapshot after the test, regardless of pass/fail.
+
+    The ``setup_console`` name is preserved for backwards compatibility with
+    tests that depend on it as a fixture.
+    """
     from rich.console import Console
 
     from terrapyne.cli.output_helpers import set_console
+    from terrapyne.rendering.logging import console, error_console
 
-    # Create a fresh console for each test
+    _MUTABLE_ATTRS = ("quiet", "_force_terminal", "no_color", "_width", "legacy_windows")
+
+    def _snapshot(c):
+        return {attr: getattr(c, attr, None) for attr in _MUTABLE_ATTRS}
+
+    def _restore(c, snap):
+        for attr, value in snap.items():
+            try:
+                setattr(c, attr, value)
+            except AttributeError:
+                # Some attributes are read-only on Rich's Console; skip silently.
+                pass
+
+    snap_console = _snapshot(console)
+    snap_error = _snapshot(error_console)
+
     new_console = Console(force_terminal=True, width=100)
     set_console(new_console)
-    return new_console
+
+    try:
+        yield new_console
+    finally:
+        _restore(console, snap_console)
+        _restore(error_console, snap_error)

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -1225,7 +1225,7 @@ def watch_exit_one(cli_result):
 )
 def follow_with_auto_apply(mock_client, run_id):
     with (
-        patch("terrapyne.cli.utils.validate_context") as v,
+        patch("terrapyne.cli.run_cmd.validate_context") as v,
         patch("terrapyne.api.client.TFCClient") as c,
         patch("time.sleep"),
     ):


### PR DESCRIPTION
## Summary
- Add `audit-patches` and `audit-ai-markers` Makefile targets to `test-fast`
- Harden `conftest.py` to snapshot/restore Rich console state across tests (fixes test isolation leaks)
- Add docs/standards (ACP, task decomposition, feedback) and docs/reference (Adzic/Farley indices)
- Introduce PLAN.md epic register

## Testing
- 789 unit/BDD tests pass (UAT failures are pre-existing — require live TFC creds)
- New audit targets verified locally