### PR TITLE
fix(ax7): deep error context surfacing on CLI failures

### DIFF
--- a/src/terrapyne/cli/error_handlers.py
+++ b/src/terrapyne/cli/error_handlers.py
@@ -24,6 +24,23 @@ def handle_cli_errors(func: F) -> F:
         except TFCAPIError as e:
             status = f" ({e.status_code})" if e.status_code else ""
             console.print(f"[red]API Error{status}:[/red] {e}")
+            if e.response is not None:
+                errors = None
+                if isinstance(e.response, dict):
+                    errors = e.response.get("errors")
+                else:
+                    try:
+                        errors = e.response.json().get("errors")
+                    except Exception:
+                        pass
+                if errors:
+                    for err in errors:
+                        title = err.get("title", "")
+                        detail = err.get("detail", "")
+                        if title:
+                            console.print(f"  [red]•[/red] [bold]{title}[/bold]")
+                        if detail:
+                            console.print(f"    {detail}")
             raise typer.Exit(code=1) from None
         except (TerrapyneError, ValueError) as e:
             console.print(f"[red]Error:[/red] {e}")

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -680,6 +680,9 @@ def run_trigger(
                 raise typer.Exit(0)
 
             if not final_run.status.is_successful:
+                error_summary = client.runs.get_error_summary(final_run)
+                if error_summary:
+                    console.print(f"\n[red]Error details:[/red]\n{error_summary}")
                 raise typer.Exit(1)
 
         except TimeoutError as e:
@@ -778,6 +781,9 @@ def run_watch(
                 raise typer.Exit(0)
 
             if not run.status.is_successful:
+                error_summary = client.runs.get_error_summary(run)
+                if error_summary:
+                    console.print(f"\n[red]Error details:[/red]\n{error_summary}")
                 raise typer.Exit(1)
 
         except TimeoutError as e:

--- a/tests/unit/test_error_handlers.py
+++ b/tests/unit/test_error_handlers.py
@@ -1,0 +1,58 @@
+"""Tests for handle_cli_errors deep error context surfacing."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from click.exceptions import Exit
+
+from terrapyne.cli.error_handlers import handle_cli_errors
+from terrapyne.core.exceptions import TFCAPIError
+
+
+@handle_cli_errors
+def _dummy():
+    """Decorated function that raises whatever is injected."""
+    raise _dummy._exc  # type: ignore[attr-defined]
+
+
+class TestHandleCliErrorsDeepContext:
+    """handle_cli_errors surfaces structured TFC API error details."""
+
+    def test_dict_response_with_errors(self, capsys):
+        _dummy._exc = TFCAPIError(
+            "forbidden",
+            status_code=403,
+            response={"errors": [{"title": "Forbidden", "detail": "Team lacks access"}]},
+        )
+        with pytest.raises(Exit):
+            _dummy()
+        out = capsys.readouterr().out
+        assert "Forbidden" in out
+        assert "Team lacks access" in out
+
+    def test_response_object_with_json_method(self, capsys):
+        resp = MagicMock()
+        resp.json.return_value = {"errors": [{"title": "Not Found", "detail": "ws gone"}]}
+        _dummy._exc = TFCAPIError("not found", status_code=404, response=resp)
+        with pytest.raises(Exit):
+            _dummy()
+        out = capsys.readouterr().out
+        assert "Not Found" in out
+        assert "ws gone" in out
+
+    def test_response_json_raises_does_not_crash(self, capsys):
+        resp = MagicMock()
+        resp.json.side_effect = ValueError("bad json")
+        _dummy._exc = TFCAPIError("bad", status_code=500, response=resp)
+        with pytest.raises(Exit):
+            _dummy()
+        out = capsys.readouterr().out
+        assert "API Error (500)" in out
+
+    def test_no_response_still_exits(self, capsys):
+        _dummy._exc = TFCAPIError("oops", status_code=422, response=None)
+        with pytest.raises(Exit):
+            _dummy()
+        out = capsys.readouterr().out
+        assert "API Error (422)" in out
+        assert "oops" in out


### PR DESCRIPTION
## Summary
- Enrich `handle_cli_errors` to parse structured TFC API error responses (title + detail)
- Surface `get_error_summary` output on `run trigger` and `run watch` failures
- Add unit tests for all error_handlers response parsing paths

## Testing
- 793 unit/BDD tests pass (includes 4 new error_handlers tests)
- UAT failures are pre-existing (require live TFC creds)