### PR TITLE
fix(sdk): paginate RunsAPI.list beyond 100 items (EPIC-005)

### DIFF
--- a/src/terrapyne/api/runs.py
+++ b/src/terrapyne/api/runs.py
@@ -24,45 +24,52 @@ class RunsAPI:
     def list(
         self,
         workspace_id: str,
-        limit: int = 20,
+        limit: int | None = 20,
         status: str | None = None,
         include: str | None = "configuration-version,plan",
     ) -> tuple[builtins.list[Run], int]:
-        """List runs for a workspace.
+        """List runs for a workspace with honest pagination.
 
         Args:
             workspace_id: Workspace ID
-            limit: Maximum number of runs to return
+            limit: Maximum number of runs to return. None means fetch all.
             status: Filter by status (can be comma-separated list)
             include: Resources to include
 
         Returns:
             Tuple of (list of Run instances, total count)
         """
+        page_size = min(limit, 100) if limit is not None else 100
         params: dict[str, Any] = {
-            "page[size]": min(limit, 100),
+            "page[size]": page_size,
         }
         if include:
             params["include"] = include
-
         if status:
             params["filter[status]"] = status
 
         path = f"/workspaces/{workspace_id}/runs"
-        response = self.client.get(path, params=params)
+        runs: builtins.list[Run] = []
+        total_count = 0
+        page = 1
 
-        runs = []
-        data = response.get("data", [])
-        included = response.get("included", [])
-        total_count = response.get("meta", {}).get("pagination", {}).get("total-count", 0)
+        while True:
+            page_params = {**params, "page[number]": page}
+            response = self.client.get(path, params=page_params)
 
-        # Use an iterator if we need to fetch more pages (not implemented here for simplicity)
-        items_iterator = data
+            data = response.get("data", [])
+            included = response.get("included", [])
+            total_count = response.get("meta", {}).get("pagination", {}).get("total-count", 0)
 
-        for item in items_iterator:
-            runs.append(Run.from_api_response(item, included=included))
-            if len(runs) >= limit:
+            for item in data:
+                runs.append(Run.from_api_response(item, included=included))
+                if limit is not None and len(runs) >= limit:
+                    return runs, total_count
+
+            if not response.get("links", {}).get("next"):
                 break
+
+            page += 1
 
         return runs, total_count
 

--- a/tests/features/sdk_pagination.feature
+++ b/tests/features/sdk_pagination.feature
@@ -1,0 +1,21 @@
+Feature: SDK pagination is honest
+  As an SDK consumer
+  I want list APIs to either paginate or to advertise their page-size
+  So I never silently lose data
+
+  Scenario: runs.list with limit > 100 returns up to limit items
+    Given a workspace with 250 runs
+    When I call client.runs.list(workspace_id, limit=200)
+    Then the result contains 200 runs
+    And the total count metadata reports 250
+
+  Scenario: runs.list with limit None fetches all available runs
+    Given a workspace with 250 runs
+    When I call client.runs.list(workspace_id, limit=None)
+    Then the result contains 250 runs
+
+  Scenario: runs.list with limit <= 100 uses a single page
+    Given a workspace with 50 runs
+    When I call client.runs.list(workspace_id, limit=20)
+    Then the result contains 20 runs
+    And only one API request was made

--- a/tests/test_api/test_runs_pagination.py
+++ b/tests/test_api/test_runs_pagination.py
@@ -1,0 +1,127 @@
+"""Tests for RunsAPI.list pagination honesty (EPIC-005).
+
+Verifies that RunsAPI.list paginates beyond 100 when limit > 100,
+fetches all when limit is None, and respects the requested limit.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from terrapyne.api.runs import RunsAPI
+
+
+def _make_run_item(run_id: str) -> dict:
+    """Create a minimal run API response item."""
+    return {
+        "id": run_id,
+        "type": "runs",
+        "attributes": {
+            "status": "applied",
+            "created-at": "2024-01-15T10:00:00Z",
+            "message": None,
+            "auto-apply": False,
+            "is-destroy": False,
+        },
+    }
+
+
+def _make_page_response(run_ids: list[str], total_count: int, has_next: bool) -> dict:
+    """Create a paginated API response."""
+    return {
+        "data": [_make_run_item(rid) for rid in run_ids],
+        "included": [],
+        "meta": {"pagination": {"total-count": total_count}},
+        "links": {"next": "/next-page" if has_next else None},
+    }
+
+
+class TestRunsListPaginationHonesty:
+    """RunsAPI.list must paginate beyond a single page when limit > 100."""
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def api(self, mock_client):
+        return RunsAPI(mock_client)
+
+    def test_limit_greater_than_100_paginates(self, api, mock_client):
+        """Given 250 runs, limit=200 should fetch 2 pages and return 200 runs."""
+        page1_ids = [f"run-{i:03d}" for i in range(100)]
+        page2_ids = [f"run-{i:03d}" for i in range(100, 200)]
+
+        mock_client.get.side_effect = [
+            _make_page_response(page1_ids, total_count=250, has_next=True),
+            _make_page_response(page2_ids, total_count=250, has_next=True),
+        ]
+
+        runs, total_count = api.list("ws-test", limit=200)
+
+        assert len(runs) == 200
+        assert total_count == 250
+        assert mock_client.get.call_count == 2
+
+    def test_limit_none_fetches_all(self, api, mock_client):
+        """Given 250 runs, limit=None should fetch all 3 pages."""
+        page1_ids = [f"run-{i:03d}" for i in range(100)]
+        page2_ids = [f"run-{i:03d}" for i in range(100, 200)]
+        page3_ids = [f"run-{i:03d}" for i in range(200, 250)]
+
+        mock_client.get.side_effect = [
+            _make_page_response(page1_ids, total_count=250, has_next=True),
+            _make_page_response(page2_ids, total_count=250, has_next=True),
+            _make_page_response(page3_ids, total_count=250, has_next=False),
+        ]
+
+        runs, total_count = api.list("ws-test", limit=None)
+
+        assert len(runs) == 250
+        assert total_count == 250
+        assert mock_client.get.call_count == 3
+
+    def test_limit_within_single_page_no_extra_requests(self, api, mock_client):
+        """limit=20 with 50 available should make one request and return 20."""
+        all_ids = [f"run-{i:03d}" for i in range(50)]
+
+        mock_client.get.return_value = _make_page_response(all_ids, total_count=50, has_next=False)
+
+        runs, total_count = api.list("ws-test", limit=20)
+
+        assert len(runs) == 20
+        assert total_count == 50
+        assert mock_client.get.call_count == 1
+
+    def test_pagination_passes_page_number(self, api, mock_client):
+        """Verify page[number] increments on each request."""
+        page1_ids = [f"run-{i:03d}" for i in range(100)]
+        page2_ids = [f"run-{i:03d}" for i in range(100, 150)]
+
+        mock_client.get.side_effect = [
+            _make_page_response(page1_ids, total_count=150, has_next=True),
+            _make_page_response(page2_ids, total_count=150, has_next=False),
+        ]
+
+        _runs, _total_count = api.list("ws-test", limit=150)
+
+        # Check page numbers in calls
+        first_call_params = mock_client.get.call_args_list[0][1]["params"]
+        second_call_params = mock_client.get.call_args_list[1][1]["params"]
+        assert first_call_params["page[number]"] == 1
+        assert second_call_params["page[number]"] == 2
+
+    def test_status_filter_preserved_across_pages(self, api, mock_client):
+        """Status filter must be sent on every page request."""
+        page1_ids = [f"run-{i:03d}" for i in range(100)]
+        page2_ids = [f"run-{i:03d}" for i in range(100, 120)]
+
+        mock_client.get.side_effect = [
+            _make_page_response(page1_ids, total_count=120, has_next=True),
+            _make_page_response(page2_ids, total_count=120, has_next=False),
+        ]
+
+        _runs, _total_count = api.list("ws-test", limit=120, status="errored")
+
+        for c in mock_client.get.call_args_list:
+            assert c[1]["params"]["filter[status]"] == "errored"


### PR DESCRIPTION
## Summary

`RunsAPI.list(workspace_id, limit=200)` previously issued a single page request capped at 100, silently truncating results. This fix makes it paginate across multiple pages, respecting the requested limit.

## Changes

- **`src/terrapyne/api/runs.py`**: Rewrite `RunsAPI.list` to iterate pages until `limit` is satisfied or no more pages exist. `limit=None` fetches all.
- **`tests/test_api/test_runs_pagination.py`**: 5 unit tests covering multi-page, single-page, limit=None, page numbering, and filter preservation.
- **`tests/features/sdk_pagination.feature`**: BDD feature file specifying the pagination honesty contract.

## Acceptance Criteria Met

- ✅ `RunsAPI.list` paginates beyond 100 by default, capped only at the requested `limit`
- ✅ `limit=None` fetches all available runs
- ✅ Status filters preserved across pages

## Testing

```
881 passed, 10 warnings in 20.91s
```