### PR TITLE
fix(api): paginate RunTriggersAPI.list to prevent silent truncation

### DIFF
--- a/src/terrapyne/api/run_triggers.py
+++ b/src/terrapyne/api/run_triggers.py
@@ -26,15 +26,26 @@ class RunTriggersAPI:
             List of RunTrigger instances
         """
         path = f"/workspaces/{workspace_id}/run-triggers"
-        response = self.client.get(
-            path,
-            params={"filter[run-trigger][type]": "inbound", "include": "source-workspace"},
-        )
-        included = response.get("included", [])
-        return [
-            RunTrigger.from_api_response(item, included=included)
-            for item in response.get("data", [])
-        ]
+        params: dict[str, Any] = {
+            "filter[run-trigger][type]": "inbound",
+            "include": "source-workspace",
+            "page[size]": 100,
+        }
+        triggers: list[RunTrigger] = []
+        page = 1
+
+        while True:
+            page_params = {**params, "page[number]": page}
+            response = self.client.get(path, params=page_params)
+            included = response.get("included", [])
+            for item in response.get("data", []):
+                triggers.append(RunTrigger.from_api_response(item, included=included))
+
+            if not response.get("links", {}).get("next"):
+                break
+            page += 1
+
+        return triggers
 
     def add(self, workspace_id: str, source_workspace_id: str) -> RunTrigger:
         """Add an upstream run trigger to a workspace.

--- a/tests/test_api/test_run_triggers.py
+++ b/tests/test_api/test_run_triggers.py
@@ -71,8 +71,34 @@ class TestRunTriggersAPIList:
         assert triggers[0].source_workspace_name == "up-ws"
 
     def test_list_returns_empty_for_no_triggers(self, api, mock_client):
-        mock_client.get.return_value = {"data": [], "included": []}
+        mock_client.get.return_value = {
+            "data": [],
+            "included": [],
+            "links": {},
+            "meta": {"pagination": {"total-count": 0}},
+        }
         assert api.list("ws-downstream1") == []
+
+    def test_list_paginates_all_pages(self, api, mock_client):
+        """BF3: list must follow pagination links, not silently truncate."""
+        page1 = {
+            "data": [_trigger_response(id="rt-1", source_ws_id="ws-up1")],
+            "included": [_included_workspace(id="ws-up1", name="up1")],
+            "links": {"next": "/workspaces/ws-down/run-triggers?page%5Bnumber%5D=2"},
+            "meta": {"pagination": {"total-count": 2}},
+        }
+        page2 = {
+            "data": [_trigger_response(id="rt-2", source_ws_id="ws-up2")],
+            "included": [_included_workspace(id="ws-up2", name="up2")],
+            "links": {},
+            "meta": {"pagination": {"total-count": 2}},
+        }
+        mock_client.get.side_effect = [page1, page2]
+        triggers = api.list("ws-downstream1")
+        assert len(triggers) == 2
+        assert triggers[0].id == "rt-1"
+        assert triggers[1].id == "rt-2"
+        assert mock_client.get.call_count == 2
 
 
 class TestRunTriggersAPIAdd:


### PR DESCRIPTION
## Summary

`RunTriggersAPI.list` performed a single unpaginated request, silently dropping results beyond the default page size (same class of bug as the original `RunsAPI.list` fixed in EPIC-005).

## Changes

- Added pagination loop to `RunTriggersAPI.list` matching the pattern in `RunsAPI.list`
- Added test proving multi-page results are fully collected

## Testing

- New test: `test_list_paginates_all_pages` — mocks two pages and asserts both are returned
- All 885 existing tests pass with no regressions

Fixes BF3