### PR TITLE
fix(tests): make test suite repeatable under randomised ordering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,4 +105,5 @@ dev = [
     "import-linter>=2.11",
     "pytest>=9.0.3",
     "pytest-bdd>=7.1.0",
+    "pytest-randomly==3.16.0",
 ]

--- a/tests/unit/test_sdk_namespace.py
+++ b/tests/unit/test_sdk_namespace.py
@@ -1,18 +1,22 @@
 """Test SDK namespace deprecation warning."""
 
+import importlib
+import sys
 import warnings
 
 
 def test_sdk_namespace_deprecated():
     """Test that importing from terrapyne.sdk issues a deprecation warning."""
+    # Evict cached module so the module-level warnings.warn() fires again.
+    sys.modules.pop("terrapyne.sdk", None)
+
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        # This should trigger the deprecation warning
-        import terrapyne.sdk  # noqa: F401
+        import terrapyne.sdk
+
+        importlib.reload(terrapyne.sdk)
 
         # Check that a warning was issued
-        assert len(w) >= 1
-        # Find the deprecation warning
         deprecation_warnings = [
             warning for warning in w if issubclass(warning.category, DeprecationWarning)
         ]

--- a/uv.lock
+++ b/uv.lock
@@ -898,6 +898,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/68/d221ed7f4a2a49a664da721b8e87b52af6dd317af2a6cb51549cf17ac4b8/pytest_randomly-3.16.0.tar.gz", hash = "sha256:11bf4d23a26484de7860d82f726c0629837cf4064b79157bd18ec9d41d7feb26", size = 13367, upload-time = "2024-10-25T15:45:34.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/70/b31577d7c46d8e2f9baccfed5067dd8475262a2331ffb0bfdf19361c9bde/pytest_randomly-3.16.0-py3-none-any.whl", hash = "sha256:8633d332635a1a0983d3bba19342196807f6afb17c3eef78e02c2f85dade45d6", size = 8396, upload-time = "2024-10-25T15:45:32.78Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1143,6 +1155,7 @@ dev = [
     { name = "import-linter" },
     { name = "pytest" },
     { name = "pytest-bdd" },
+    { name = "pytest-randomly" },
 ]
 
 [package.metadata]
@@ -1178,6 +1191,7 @@ dev = [
     { name = "import-linter", specifier = ">=2.11" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-bdd", specifier = ">=7.1.0" },
+    { name = "pytest-randomly", specifier = "==3.16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves EPIC-001: Restore Test-Suite Repeatability.

### Problem
The test suite had one order-dependent test (`test_sdk_namespace_deprecated`) that failed when `terrapyne.sdk` was already cached in `sys.modules` from a prior test. This caused intermittent failures under randomised test ordering.

### Changes
- **Added `pytest-randomly==3.16.0`** to dev dependencies — enables randomised test execution to catch order-dependent failures in CI.
- **Fixed `test_sdk_namespace_deprecated`** — evicts the cached module from `sys.modules` and uses `importlib.reload()` so the module-level `warnings.warn()` fires regardless of import order.

### Verification
- ✅ 10 consecutive random seeds pass (884 tests each)
- ✅ All test subdirectories pass in isolation (`test_cli`, `test_api`, `unit`, `test_models`, `test_rendering`, `test_docs`)
- ✅ `make test-fast` completes in <1s
- ✅ Pre-commit hooks pass (ruff, ruff format, mypy)
- ✅ Zero broken `patch()` targets (deprecated `terrapyne.cli.utils.validate_context` already cleaned up in PR #121)