### PR TITLE
fix: Run cancel command, discard state routing, and workspace lock/unlock (B16, B17, B18)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,14 +62,28 @@ Based on recent Agent-Native CLI design research, the backlog is currently struc
 | B13 | `run trigger` exits non-zero on success — breaks `&&` chains and scripting | 🟡 | S | 2.0 | 🔄 fix/scripting-polish |
 | B14 | `workspace var-rm` no `--yes`/`-y` flag — always prompts interactively, unusable in scripts | 🟡 | S | 2.0 | 🔄 fix/scripting-polish |
 | B15 | `--quiet` flag position-sensitive — `terrapyne workspace list --quiet` fails; must be `terrapyne --quiet workspace list` | 🟢 | S | 1.0 | 🔄 fix/scripting-polish (partial: `workspace --quiet list` now works) |
+| **BUGS (ASG BB v4.0 session, June 2026)** |
+| B16 | `run cancel` missing — pending runs cannot be cancelled; only discard exists (valid for cost_estimated/policy_checked only) | 🔴 | S | 4.0 | TODO |
+| B17 | `run discard` returns 409 on pending runs — should auto-route to cancel or surface actionable error | 🔴 | S | 4.0 | TODO |
+| B18 | `workspace unlock` missing — locked workspaces require raw API call to unblock | 🔴 | S | 4.0 | TODO |
+| B19 | `run trigger --wait` hangs on `pending` when predecessor run awaits apply — no timeout, no hint | 🔴 | M | 2.0 | TODO |
+| B20 | `run trigger` no `--workspace-id` override — context auto-detection breaks after workspace rename | 🟡 | S | 2.0 | TODO |
+| B21 | `run watch` / `run trigger` timeout hardcoded at 1800s — too short for agent-pool execution mode | 🟡 | S | 2.0 | TODO |
+| **AGENT EXPERIENCE (AX) GAPS** |
+| AX8 | `run trigger --wait` not default in agent context — agents must know to pass `--wait` or they fire-and-forget | 🔴 | M | 2.0 | TODO |
+| AX9 | `run trigger` silent on VCS-connected workspaces — agent pushes commit + triggers run, causing duplicate runs and wrong run being followed | 🔴 | M | 2.0 | TODO |
+| AX10 | Non-zero exits lack structured `hints` array — agent context exits should include corrective command suggestions in JSON envelope | 🟡 | M | 1.0 | TODO |
 | **NEW FEATURES** |
 | F13 | `workspace set-branch <workspace> <branch>` — switch VCS branch from CLI | 🟡 | S | 2.0 | ✅ |
+| F14 | `workspace rename <old> <new>` — rename workspace from CLI | 🟡 | S | 2.0 | TODO |
+| F15 | `workspace set-working-dir <workspace> <dir>` — set working directory from CLI | 🟢 | S | 1.0 | TODO |
 | F4 | Workspace notifications (webhook/Slack config) | 🟡 | M | 1.0 | TODO |
 | F5 | Policy sets / Sentinel outcome reporting | 🟡 | M | 1.0 | TODO |
 | F6 | Private registry query (modules + providers) | 🟡 | M | 1.0 | TODO |
 | F7 | Agent pools — list and show self-hosted agents | 🟡 | M | 1.0 | TODO |
 | F8 | SSH keys / VCS OAuth token management | 🟢 | L | 0.33 | TODO |
 | F10 | Context honoring (org/workspace) in `run list` and `run logs` | 🟡 | S | 2.0 | TODO |
+| F16 | `run apply --auto-apply` flag — currently only on `run watch`; apply + watch in one command | 🟢 | S | 1.0 | TODO |
 | **COMPLETED** |
 | F9 | `workspace update` command and API update method | 🔴 | M | 2.0 | ✅ |
 | B3 | `paginate_with_meta` `included` leaks only last page | 🟡 | S | 2.0 | ✅ |
@@ -846,3 +860,161 @@ These features are specifically designed to reduce the "glue logic" (bash pipes,
 **Fix**: Implement context discovery (similar to `tfc run trigger`) so that `run list` and `run logs` automatically infer `--workspace` and `--org` from the `.terraform` directory or `terraform.tf` files if invoked without explicit flags.
 **Success Criteria**:
 - `terrapyne run list` executed in a directory with initialized terraform backend prints the runs for the inferred workspace.
+
+---
+
+### B16 — `run cancel` missing
+
+**Intent**: Allow cancellation of pending or planning runs, which cannot be discarded.
+
+**Context**: TFC has two distinct stop operations — cancel (`/actions/cancel`, valid for pending/planning/applying) and discard (`/actions/discard`, valid for cost_estimated/policy_checked). Only `run discard` exists in terrapyne. Agents and scripts hitting pending runs are forced to use raw API calls.
+
+**Success Criteria**:
+- `tfc run cancel <run-id> [-m "reason"]` cancels a pending or planning run
+- Mirrors the existing `run discard` command structure
+- JSON output supported (`--format json`)
+
+---
+
+### B17 — `run discard` returns 409 on pending runs
+
+**Intent**: Surface an actionable error (or auto-route) when discard is called on a run state that requires cancel instead.
+
+**Context**: `run discard` returns HTTP 409 on pending runs. The TFC API distinguishes discard (post-plan) from cancel (pre/during-plan). The CLI should either detect the run state and route to the correct endpoint, or surface: _"Run is pending — use `tfc run cancel <id>` instead."_
+
+**Success Criteria**:
+- `tfc run discard <pending-run-id>` returns exit 1 with a clear error naming `run cancel` as the remedy
+- OR auto-routes to cancel when run state is pending/planning/applying
+
+---
+
+### B18 — `workspace unlock` missing
+
+**Intent**: Unlock a workspace locked by a cancelled or errored run.
+
+**Context**: Workspaces can be left locked after a run errors or is cancelled mid-apply. No CLI command exists to unlock; the only recourse is `POST /workspaces/{id}/actions/unlock` via raw API.
+
+**Success Criteria**:
+- `tfc workspace unlock <workspace>` unlocks the workspace
+- `tfc workspace lock <workspace>` for completeness (if not already implemented)
+- Confirmation guard for lock; unlock is non-destructive
+
+---
+
+### B19 — `run trigger --wait` hangs on `pending` when predecessor awaits apply
+
+**Intent**: When `--wait` sees a run stuck in `pending`, detect why and exit with an actionable structured hint rather than spinning indefinitely.
+
+**Context**: In non-auto-apply workspaces, a run stays `pending` until preceding runs are applied or discarded. Agents running `run trigger --wait` spin forever assuming the run will become active. The CLI should detect this condition and exit non-zero with structured JSON identifying the blocking run.
+
+**Action**: After N seconds of no state progress, check for preceding runs in `cost_estimated` or `planned` state. Exit non-zero with:
+```json
+{
+  "status": "pending",
+  "reason": "blocked_by_predecessor",
+  "predecessor_run_id": "run-xxx",
+  "hints": ["tfc run apply run-xxx", "tfc run discard run-xxx"]
+}
+```
+
+**Success Criteria**:
+- `run trigger --wait` exits non-zero after configurable stall timeout (default 120s of no progress)
+- JSON envelope includes `predecessor_run_id` and `hints` when blocked
+- Human output names the predecessor and suggests the corrective command
+- `--stall-timeout` flag to override the stall detection window
+
+---
+
+### B20 — No `--workspace-id` override for workspace resolution
+
+**Intent**: Allow commands that auto-detect workspace from `terraform.tf` to be overridden with an explicit workspace ID or name.
+
+**Context**: After a workspace rename, `terraform.tf` still references the old name. Any command using context auto-detection fails with 404. Users are forced to use raw API calls with the workspace ID directly.
+
+**Action**: Add `--workspace-id` (and `--workspace` name override) to `run trigger`, `run list`, `run logs`, `run follow`, and any other command that performs context auto-detection.
+
+**Success Criteria**:
+- `tfc run trigger --workspace-id ws-xxx` bypasses `terraform.tf` auto-detection
+- `tfc run list --workspace my-renamed-ws` overrides auto-detected name
+- Flags documented in CLI reference
+
+---
+
+### B21 — `run watch` / `run trigger` timeout too short for agent pools
+
+**Intent**: Allow configurable timeout for run polling to accommodate slow agent pool pickup.
+
+**Context**: The hardcoded 1800s timeout is hit when TFC agent pools are slow to pick up jobs. Operators using self-hosted agent pools regularly see `"did not complete within 1800.0s (current status: pending)"`.
+
+**Success Criteria**:
+- `--timeout <seconds>` flag on `run trigger` and `run watch` (0 = infinite, Ctrl-C to abort)
+- Default remains 1800s for backwards compatibility
+
+---
+
+### AX8 — `run trigger` should default to `--wait` in agent context
+
+**Intent**: Eliminate the agent trap of fire-and-forget triggering — agents that don't know to pass `--wait` get a run ID and then have no way to track progress without additional commands.
+
+**Context**: In agent context (detected via `agent_context.py`), `run trigger` should block by default. In TTY/human context, it should remain fire-and-forget. Explicit `--wait` / `--no-wait` override in either direction.
+
+**Success Criteria**:
+- `run trigger` in agent context (non-TTY stdout) blocks until terminal state by default
+- `run trigger --no-wait` in agent context returns immediately with run ID
+- `run trigger --wait` in human context blocks (opt-in, current behaviour)
+- JSON exit envelope on completion/failure per B19
+
+---
+
+### AX9 — `run trigger` silent on VCS-connected workspaces
+
+**Intent**: Warn agents before they create a duplicate run on a VCS-connected workspace where a git push already triggered a run.
+
+**Context**: When an agent pushes a commit and then calls `run trigger`, TFC creates two runs. The agent follows the manually-triggered run which stays `pending` behind the VCS-triggered run. The VCS-triggered run reaches `cost_estimated` and waits for apply; the agent's run never becomes active.
+
+**Action**: Before creating a run, check if the workspace has VCS integration (`vcs-repo` relationship). If yes, emit to stderr (or include in JSON `warnings` field):
+```
+warning: workspace "my-ws" has VCS integration — a run may already have been
+triggered by your git push. Check: tfc run list --workspace my-ws
+```
+Run is still created (soft warn, not hard stop) so agents can proceed if they know what they're doing.
+
+**Success Criteria**:
+- `run trigger` on a VCS-connected workspace emits a warning before creating the run
+- `--format json` output includes `"warnings": ["vcs_integration_detected"]`
+- `--force` flag suppresses the warning for agents that explicitly want dual runs
+
+---
+
+### AX10 — Non-zero exits lack structured `hints`
+
+**Intent**: Complete the AX-actionable-errors principle: every non-zero exit in agent context should include a `hints` array of corrective commands.
+
+**Context**: AX7 added `title` and `detail` from TFC API errors. The next step is adding `hints` — concrete CLI commands the agent can run to recover. This turns dead-end failures into self-healing workflows.
+
+**Success Criteria**:
+- JSON error envelope gains a `hints: string[]` field
+- Common errors have hints: 409 conflict → `--ignore-exists`, 404 workspace → `--workspace-id`, pending blocked → `tfc run apply <id>`
+- Empty array `[]` when no hint is available (never omitted)
+
+---
+
+### F14 — `workspace rename`
+
+**Intent**: Rename a workspace from the CLI without requiring raw API calls.
+
+**Success Criteria**:
+- `tfc workspace rename <old-name> <new-name>`
+- Warns if VCS-connected (terraform.tf will need manual update)
+
+---
+
+### F16 — `run apply --auto-apply`
+
+**Intent**: Apply a specific run and watch it to completion in a single command.
+
+**Context**: `run apply <id>` approves the run but returns immediately. To then watch it, a separate `run watch --auto-apply` is needed. Agents end up writing two-step logic for a single workflow.
+
+**Success Criteria**:
+- `tfc run apply <id> --auto-apply` approves then watches until terminal state
+- Equivalent to `tfc run apply <id> && tfc run watch <id>`

--- a/src/terrapyne/api/workspaces.py
+++ b/src/terrapyne/api/workspaces.py
@@ -311,6 +311,32 @@ class WorkspaceAPI:
         response = self.client.post(path, json_data=payload)
         return Workspace.from_api_response(response["data"])
 
+    def unlock(self, workspace_id: str) -> Workspace:
+        """Unlock a workspace.
+
+        Args:
+            workspace_id: Workspace ID to unlock
+
+        Returns:
+            Updated Workspace instance
+        """
+        self.client.post(f"/workspaces/{workspace_id}/actions/unlock")
+        return self.get_by_id(workspace_id)
+
+    def lock(self, workspace_id: str, reason: str | None = None) -> Workspace:
+        """Lock a workspace.
+
+        Args:
+            workspace_id: Workspace ID to lock
+            reason: Optional reason for locking
+
+        Returns:
+            Updated Workspace instance
+        """
+        payload = {"reason": reason} if reason else None
+        self.client.post(f"/workspaces/{workspace_id}/actions/lock", json_data=payload)
+        return self.get_by_id(workspace_id)
+
     def delete(self, workspace_id: str) -> None:
         """Delete a workspace by ID.
 

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -14,8 +14,9 @@ from terrapyne.api.org_errors import get_errored_workspaces
 from terrapyne.cli.context_helpers import get_client, resolve_project_context, validate_context
 from terrapyne.cli.error_handlers import handle_cli_errors
 from terrapyne.cli.output_helpers import effective_format, emit_json
+from terrapyne.core.exceptions import TFCConflictError
 from terrapyne.models.run import Run
-from terrapyne.rendering.logging import console
+from terrapyne.rendering.logging import console, error_console
 from terrapyne.rendering.rich_tables import render_run_detail, render_runs
 
 app = typer.Typer(help="Run management commands")
@@ -933,7 +934,15 @@ def run_discard(
 
     with get_client(ctx, organization=org) as client:
         console.print(f"[dim]Discarding run:[/dim] {run_id}")
-        run = client.runs.discard(run_id, comment=comment)
+        try:
+            run = client.runs.discard(run_id, comment=comment)
+        except TFCConflictError:
+            current = client.runs.get(run_id)
+            error_console.print(
+                f"[red]Error:[/red] Run is in '{current.status.value}' state"
+                f" — use `tfc run cancel {run_id}` instead."
+            )
+            raise typer.Exit(1) from None
         console.print(f"[green]✓[/green] Run {run_id} discarded (Status: {run.status.value})")
 
 

--- a/src/terrapyne/cli/run_cmd.py
+++ b/src/terrapyne/cli/run_cmd.py
@@ -937,6 +937,33 @@ def run_discard(
         console.print(f"[green]✓[/green] Run {run_id} discarded (Status: {run.status.value})")
 
 
+@app.command("cancel")
+@handle_cli_errors
+def run_cancel(
+    ctx: typer.Context,
+    run_id: Annotated[str, typer.Argument(help="Run ID")],
+    organization: Annotated[
+        str | None,
+        typer.Option(
+            "--organization",
+            "-o",
+            help="TFC organization (auto-detected from context if available)",
+        ),
+    ] = None,
+    comment: Annotated[
+        str | None,
+        typer.Option("--comment", "-m", help="Reason for cancelling"),
+    ] = None,
+):
+    """Cancel a pending, planning, or applying run."""
+    org, _ = validate_context(organization)
+
+    with get_client(ctx, organization=org) as client:
+        console.print(f"[dim]Cancelling run:[/dim] {run_id}")
+        run = client.runs.cancel(run_id, comment=comment)
+        console.print(f"[green]✓[/green] Run {run_id} cancelled (Status: {run.status.value})")
+
+
 @app.command("parse-plan")
 @handle_cli_errors
 def run_parse_plan(

--- a/src/terrapyne/cli/workspace_cmd.py
+++ b/src/terrapyne/cli/workspace_cmd.py
@@ -799,6 +799,53 @@ def workspace_delete(
     console.print(f"[green]✓[/green] Deleted workspace: {name}")
 
 
+@app.command("unlock")
+@handle_cli_errors
+def workspace_unlock(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Workspace name to unlock"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+):
+    """Unlock a workspace locked by a cancelled or errored run."""
+    org = resolve_organization(organization)
+    if not org:
+        console.print("[red]Error: Organization not specified and not found in context.[/red]")
+        raise typer.Exit(1)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(name, org)
+        client.workspaces.unlock(ws.id)
+
+    console.print(f"[green]✓[/green] Unlocked workspace: {name}")
+
+
+@app.command("lock")
+@handle_cli_errors
+def workspace_lock(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Workspace name to lock"),
+    organization: str | None = typer.Option(None, "--organization", "-o", help="TFC organization"),
+    reason: str | None = typer.Option(None, "--reason", "-r", help="Reason for locking"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Lock a workspace to prevent runs from being created."""
+    org = resolve_organization(organization)
+    if not org:
+        console.print("[red]Error: Organization not specified and not found in context.[/red]")
+        raise typer.Exit(1)
+
+    with get_client(ctx, organization=org) as client:
+        ws = client.workspaces.get(name, org)
+
+        if not yes and not typer.confirm(f"Lock workspace '{name}' in '{org}'?"):
+            console.print("[yellow]Aborted.[/yellow]")
+            raise typer.Exit(0)
+
+        client.workspaces.lock(ws.id, reason=reason)
+
+    console.print(f"[green]✓[/green] Locked workspace: {name}")
+
+
 @app.command("costs")
 @handle_cli_errors
 def workspace_costs(

--- a/tests/features/run_lifecycle.feature
+++ b/tests/features/run_lifecycle.feature
@@ -41,6 +41,13 @@ Feature: Infrastructure Change Lifecycle
     Then the run is cancelled
     And the output confirms cancellation
 
+  # B17 — actionable error when discarding a pending/planning run
+  Scenario: Discard a pending run surfaces actionable error
+    Given a run "run-pending456" exists in "pending" status
+    When I discard the run "run-pending456"
+    Then the command exits with code 1
+    And the error output contains "use `tfc run cancel run-pending456` instead"
+
   Scenario: Triggering a change with a descriptive message
     When I trigger a plan for "my-app-dev" with the message "Release v2.0"
     Then the new execution should be labeled with "Release v2.0"

--- a/tests/features/run_lifecycle.feature
+++ b/tests/features/run_lifecycle.feature
@@ -35,6 +35,12 @@ Feature: Infrastructure Change Lifecycle
     Then the execution should be halted
     And its final status should be "discarded"
 
+  Scenario: Cancel a pending run
+    Given a run "run-abc123" exists in "pending" status
+    When I cancel the run "run-abc123"
+    Then the run is cancelled
+    And the output confirms cancellation
+
   Scenario: Triggering a change with a descriptive message
     When I trigger a plan for "my-app-dev" with the message "Release v2.0"
     Then the new execution should be labeled with "Release v2.0"

--- a/tests/features/workspace.feature
+++ b/tests/features/workspace.feature
@@ -275,3 +275,31 @@ Feature: Workspace Operations
     When I try to delete workspace "ghost-workspace" in "test-org"
     Then I should see error message containing "not found"
     And exit code should be 1
+
+  # B18 — workspace lock and unlock commands
+
+  Scenario: Unlock a workspace locked by a cancelled run
+    Given workspace "locked-ws" exists in "test-org"
+    When I unlock workspace "locked-ws"
+    Then the workspace should be unlocked
+    And output should show "Unlocked workspace: locked-ws"
+    And exit code should be 0
+
+  Scenario: Lock a workspace with a reason
+    Given workspace "my-app-dev" exists in "test-org"
+    When I lock workspace "my-app-dev" with reason "maintenance" and --yes
+    Then the workspace should be locked
+    And output should show "Locked workspace: my-app-dev"
+    And exit code should be 0
+
+  Scenario: Lock a workspace prompts for confirmation without --yes
+    Given workspace "my-app-dev" exists in "test-org"
+    When I lock workspace "my-app-dev" without --yes and confirm yes
+    Then the workspace should be locked
+    And exit code should be 0
+
+  Scenario: Lock aborted when user declines confirmation
+    Given workspace "my-app-dev" exists in "test-org"
+    When I lock workspace "my-app-dev" without --yes and confirm no
+    Then output should show "Aborted"
+    And exit code should be 0

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -111,6 +111,11 @@ def test_discard_run():
     pass
 
 
+@scenario("../features/run_lifecycle.feature", "Cancel a pending run")
+def test_cancel_run():
+    pass
+
+
 @scenario("../features/run_lifecycle.feature", "Triggering a change with a descriptive message")
 def test_trigger_run_with_message():
     pass
@@ -723,6 +728,42 @@ def check_halted(cli_result, status=None):
     assert cli_result.exit_code == 0
     if status:
         assert status in cli_result.stdout.lower()
+
+
+# B16 — run cancel step definitions
+
+
+@given(parsers.parse('a run "{run_id}" exists in "{status}" status'), target_fixture="mock_client")
+def run_exists_in_status(run_id, status):
+    m = MagicMock()
+    m.runs.get.return_value = Run.model_construct(id=run_id, status=RunStatus(status))
+    return m
+
+
+@when(parsers.parse('I cancel the run "{run_id}"'), target_fixture="cli_result")
+def cancel_run(run_id, mock_client):
+    with (
+        patch("terrapyne.cli.run_cmd.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+
+        mock_client.runs.cancel.return_value = Run.model_construct(
+            id=run_id, status=RunStatus.CANCELED
+        )
+
+        return runner.invoke(app, ["run", "cancel", run_id, "-o", "test-org"])
+
+
+@then("the run is cancelled")
+def check_run_cancelled(cli_result):
+    assert cli_result.exit_code == 0
+
+
+@then("the output confirms cancellation")
+def check_cancellation_output(cli_result):
+    assert "cancel" in cli_result.stdout.lower()
 
 
 @then(parsers.parse('the new execution should be labeled with "{message}"'))

--- a/tests/test_cli/test_run_commands.py
+++ b/tests/test_cli/test_run_commands.py
@@ -116,6 +116,14 @@ def test_cancel_run():
     pass
 
 
+@scenario(
+    "../features/run_lifecycle.feature",
+    "Discard a pending run surfaces actionable error",
+)
+def test_discard_pending_run_actionable_error():
+    pass
+
+
 @scenario("../features/run_lifecycle.feature", "Triggering a change with a descriptive message")
 def test_trigger_run_with_message():
     pass
@@ -1420,3 +1428,35 @@ def output_not_say(cli_result, text):
     assert call_kwargs.kwargs.get("log_read_url") == _ARCHIVIST_URL, (
         "get_plan_logs not called with the plan's log_read_url"
     )
+
+
+# B17 — actionable error when discarding a pending/planning run
+
+
+@when(parsers.parse('I discard the run "{run_id}"'), target_fixture="cli_result")
+def discard_pending_run(run_id, mock_client):
+    from terrapyne.core.exceptions import TFCConflictError
+
+    with (
+        patch("terrapyne.cli.run_cmd.validate_context") as v,
+        patch("terrapyne.api.client.TFCClient") as c,
+    ):
+        v.return_value = ("test-org", None)
+        c.return_value.__enter__.return_value = mock_client
+
+        mock_client.runs.discard.side_effect = TFCConflictError("conflict", status_code=409)
+
+        result = runner.invoke(app, ["run", "discard", run_id, "-o", "test-org"])
+        result.mock_client = mock_client
+        return result
+
+
+@then("the command exits with code 1")
+def check_exit_code_1(cli_result):
+    assert cli_result.exit_code == 1
+
+
+@then(parsers.parse('the error output contains "{text}"'))
+def check_error_output_contains(cli_result, text):
+    combined = (cli_result.output or "") + (cli_result.stdout or "")
+    assert text in combined, f"Expected {text!r} in output:\n{combined}"

--- a/tests/test_cli/test_workspace_commands.py
+++ b/tests/test_cli/test_workspace_commands.py
@@ -1707,3 +1707,185 @@ def check_not_found_error(delete_workspace_not_found):
     result = delete_workspace_not_found["result"]
     assert result.exit_code == 1
     assert "not found" in result.stdout.lower()
+
+
+# B18 — workspace lock and unlock commands
+
+
+@scenario("../features/workspace.feature", "Unlock a workspace locked by a cancelled run")
+def test_workspace_unlock():
+    pass
+
+
+@scenario("../features/workspace.feature", "Lock a workspace with a reason")
+def test_workspace_lock_with_reason():
+    pass
+
+
+@scenario(
+    "../features/workspace.feature",
+    "Lock a workspace prompts for confirmation without --yes",
+)
+def test_workspace_lock_confirm():
+    pass
+
+
+@scenario("../features/workspace.feature", "Lock aborted when user declines confirmation")
+def test_workspace_lock_aborted():
+    pass
+
+
+@given('workspace "locked-ws" exists in "test-org"')
+def _():
+    pass
+
+
+@given('workspace "my-app-dev" exists in "test-org"')
+def _():
+    pass
+
+
+@pytest.fixture
+@when('I unlock workspace "locked-ws"')
+def unlock_workspace_result():
+    existing_ws = Workspace.from_api_response(
+        workspace_response(id="ws-locked-0001", name="locked-ws")["data"]
+    )
+    unlocked_ws = Workspace.from_api_response(
+        workspace_response(id="ws-locked-0001", name="locked-ws")["data"]
+    )
+    with (
+        patch("terrapyne.cli.context_helpers.resolve_organization") as mock_org,
+        patch("terrapyne.api.client.TFCClient") as mock_client,
+    ):
+        mock_org.return_value = "test-org"
+        mock_instance = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_instance
+        mock_instance.workspaces.get.return_value = existing_ws
+        mock_instance.workspaces.unlock.return_value = unlocked_ws
+
+        result = runner.invoke(
+            app, ["workspace", "unlock", "locked-ws", "--organization", "test-org"]
+        )
+        return {"result": result}
+
+
+@then("the workspace should be unlocked")
+def check_workspace_unlocked(unlock_workspace_result):
+    result = unlock_workspace_result["result"]
+    assert result.exit_code == 0, f"Command failed: {result.stdout}"
+
+
+@then('output should show "Unlocked workspace: locked-ws"')
+def check_unlock_output(unlock_workspace_result):
+    result = unlock_workspace_result["result"]
+    assert "Unlocked workspace: locked-ws" in result.stdout
+
+
+@pytest.fixture
+@when('I lock workspace "my-app-dev" with reason "maintenance" and --yes')
+def lock_workspace_yes():
+    existing_ws = Workspace.from_api_response(
+        workspace_response(id="ws-myappdev001", name="my-app-dev")["data"]
+    )
+    locked_ws = Workspace.from_api_response(
+        workspace_response(id="ws-myappdev001", name="my-app-dev")["data"]
+    )
+    with (
+        patch("terrapyne.cli.context_helpers.resolve_organization") as mock_org,
+        patch("terrapyne.api.client.TFCClient") as mock_client,
+    ):
+        mock_org.return_value = "test-org"
+        mock_instance = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_instance
+        mock_instance.workspaces.get.return_value = existing_ws
+        mock_instance.workspaces.lock.return_value = locked_ws
+
+        result = runner.invoke(
+            app,
+            [
+                "workspace",
+                "lock",
+                "my-app-dev",
+                "--organization",
+                "test-org",
+                "--reason",
+                "maintenance",
+                "--yes",
+            ],
+        )
+        return {"result": result}
+
+
+@then("the workspace should be locked")
+def check_workspace_locked(lock_workspace_yes):
+    result = lock_workspace_yes["result"]
+    assert result.exit_code == 0, f"Command failed: {result.stdout}"
+
+
+@then('output should show "Locked workspace: my-app-dev"')
+def check_lock_output(lock_workspace_yes):
+    result = lock_workspace_yes["result"]
+    assert "Locked workspace: my-app-dev" in result.stdout
+
+
+@pytest.fixture
+@when('I lock workspace "my-app-dev" without --yes and confirm yes')
+def lock_workspace_confirm_yes():
+    existing_ws = Workspace.from_api_response(
+        workspace_response(id="ws-myappdev001", name="my-app-dev")["data"]
+    )
+    locked_ws = Workspace.from_api_response(
+        workspace_response(id="ws-myappdev001", name="my-app-dev")["data"]
+    )
+    with (
+        patch("terrapyne.cli.context_helpers.resolve_organization") as mock_org,
+        patch("terrapyne.api.client.TFCClient") as mock_client,
+    ):
+        mock_org.return_value = "test-org"
+        mock_instance = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_instance
+        mock_instance.workspaces.get.return_value = existing_ws
+        mock_instance.workspaces.lock.return_value = locked_ws
+
+        result = runner.invoke(
+            app,
+            ["workspace", "lock", "my-app-dev", "--organization", "test-org"],
+            input="y\n",
+        )
+        return {"result": result}
+
+
+@then("the workspace should be locked")
+def _check_workspace_locked_confirm(lock_workspace_confirm_yes):
+    result = lock_workspace_confirm_yes["result"]
+    assert result.exit_code == 0, f"Command failed: {result.stdout}"
+
+
+@pytest.fixture
+@when('I lock workspace "my-app-dev" without --yes and confirm no')
+def lock_workspace_confirm_no():
+    existing_ws = Workspace.from_api_response(
+        workspace_response(id="ws-myappdev001", name="my-app-dev")["data"]
+    )
+    with (
+        patch("terrapyne.cli.context_helpers.resolve_organization") as mock_org,
+        patch("terrapyne.api.client.TFCClient") as mock_client,
+    ):
+        mock_org.return_value = "test-org"
+        mock_instance = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_instance
+        mock_instance.workspaces.get.return_value = existing_ws
+
+        result = runner.invoke(
+            app,
+            ["workspace", "lock", "my-app-dev", "--organization", "test-org"],
+            input="n\n",
+        )
+        return {"result": result}
+
+
+@then('output should show "Aborted"')
+def check_lock_aborted(lock_workspace_confirm_no):
+    result = lock_workspace_confirm_no["result"]
+    assert "Aborted" in result.stdout or "aborted" in result.stdout.lower()


### PR DESCRIPTION
## Summary

Three related gaps discovered during ASG Building Block v4.0 E2E testing where users were forced to fall back to raw `curl` calls for basic run and workspace lifecycle operations.

- **B16 — `run cancel`**: New command to cancel pending/planning/applying runs. TFC distinguishes cancel (pre-apply) from discard (post-plan); only discard existed previously.
- **B17 — `run discard` state routing**: When `run discard` is called on a pending run, TFC returns 409. The CLI now catches this, fetches the run's current status, and surfaces: _"Run is in 'pending' state — use `tfc run cancel <run-id>` instead."_
- **B18 — `workspace lock` / `workspace unlock`**: Workspaces locked by cancelled or errored runs previously required a raw `POST /workspaces/{id}/actions/unlock` API call. Two new commands cover both directions.

## Changes

| File | Change |
|------|--------|
| `src/terrapyne/cli/run_cmd.py` | Add `run cancel` command; update `run discard` to catch 409 and route |
| `src/terrapyne/api/workspaces.py` | Add `lock()` and `unlock()` API methods |
| `src/terrapyne/cli/workspace_cmd.py` | Add `workspace lock` and `workspace unlock` commands |
| `tests/features/run_lifecycle.feature` | BDD scenario for discard-on-pending routing |
| `tests/features/workspace.feature` | 4 BDD scenarios for lock/unlock |

## Test plan

- [x] BDD scenario: cancel a pending run
- [x] BDD scenario: discard a pending run surfaces actionable error naming `run cancel`
- [x] BDD scenario: workspace unlock succeeds
- [x] BDD scenario: workspace lock with and without `--yes` confirmation
- [x] 892 tests pass, 0 regressions
- [x] ruff, mypy, pre-commit hooks green